### PR TITLE
Add !pre and !post keywords

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ add_executable(${PROJECT_NAME}
     src/parser/parser.cpp
     src/scheduler/exceptions/compilationerrorexception.cpp
     src/scheduler/exceptions/linkerrorexception.cpp
+    src/scheduler/exceptions/postcompilationcommandexception.cpp
     src/scheduler/exceptions/precompilationcommandexception.cpp
     src/scheduler/pipeline/job.cpp
     src/scheduler/pipeline/pipeline.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(${PROJECT_NAME}
     src/parser/parser.cpp
     src/scheduler/exceptions/compilationerrorexception.cpp
     src/scheduler/exceptions/linkerrorexception.cpp
+    src/scheduler/exceptions/precompilationcommandexception.cpp
     src/scheduler/pipeline/job.cpp
     src/scheduler/pipeline/pipeline.cpp
     src/scheduler/executor.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(${PROJECT_NAME}
     src/parser/states/keywords/cflags.cpp
     src/parser/states/keywords/deps.cpp
     src/parser/states/keywords/files.cpp
+    src/parser/states/keywords/post.cpp
     src/parser/states/keywords/pre.cpp
     src/parser/states/keywords/project.cpp
     src/parser/states/types/array.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,9 @@ add_executable(${PROJECT_NAME}
     src/lexer/exceptions/filenotfoundexception.cpp
     src/lexer/exceptions/unexpectedlexemeexception.cpp
     src/lexer/handlers/handler.cpp
-    src/lexer/handlers/wordhandler.cpp
     src/lexer/handlers/punctuatorhandler.cpp
+    src/lexer/handlers/separatorhandler.cpp
+    src/lexer/handlers/wordhandler.cpp
     src/lexer/context.cpp
     src/lexer/lexer.cpp
     src/lexer/scanner.cpp
@@ -57,6 +58,7 @@ add_executable(${PROJECT_NAME}
     src/parser/states/state.cpp
     src/parser/states/statement.cpp
     src/parser/tokens/punctuator.cpp
+    src/parser/tokens/separator.cpp
     src/parser/tokens/token.cpp
     src/parser/mediator.cpp
     src/parser/parser.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(${PROJECT_NAME}
     src/parser/states/keywords/cflags.cpp
     src/parser/states/keywords/deps.cpp
     src/parser/states/keywords/files.cpp
+    src/parser/states/keywords/pre.cpp
     src/parser/states/keywords/project.cpp
     src/parser/states/types/array.cpp
     src/parser/states/types/string.cpp

--- a/include/lexer/handlers/separatorhandler.hpp
+++ b/include/lexer/handlers/separatorhandler.hpp
@@ -17,32 +17,31 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#pragma once
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
+#include <memory>
 
-namespace lexer
+#include "lexer/handlers/handler.hpp"
+#include "parser/tokens/separator.hpp"
+
+namespace lexer::handlers
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
+/**
+ * @brief A handler that creates "separator" tokens
+ * 
+ */
+class SeparatorHandler : public Handler
 {
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
+	using Separator = parser::tokens::Separator;
+	using Token = parser::tokens::Token;
 
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
-}
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+public:
+	/**
+	 * @brief Process the input and return the token if possible
+	 * 
+	 * @param scanner - the source of characters to process
+	 * @return std::unique_ptr<Token> - a pointer to the token or nullptr 
+	 */
+	std::unique_ptr<Token> Process(Scanner& scanner) const override;
+};
+} // namespace lexer::handlers

--- a/include/lexer/scanner.hpp
+++ b/include/lexer/scanner.hpp
@@ -76,14 +76,6 @@ protected:
       */
 	void Skip();
 
-	/**
-      * @brief Skip whitespaces
-      * 
-      * @param character - the current character
-      * @return std::optional<char> - the character next to whitespaces
-      */
-	std::optional<char> SkipWhitespaces(std::optional<char> character);
-
 protected:
 	/**
      * @brief The file which is processed

--- a/include/parser/states/keywords/post.hpp
+++ b/include/parser/states/keywords/post.hpp
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "parser/states/types/array.hpp"
+
+namespace parser::states::keywords
+{
+/**
+ * @brief A "Post" state of the parser, used to parse !pre keyword
+ * 
+ */
+class Post : public types::Array
+{
+public:
+	/**
+     * @brief Construct a new Post object
+     * 
+     * @param mediator - the associated parser's mediator
+     */
+	explicit Post(Mediator& mediator);
+
+public:
+	/**
+     * @brief Process the input from the lexer
+     * 
+     * @param lexer - the lexer which handles tokenization of the input file
+     */
+	void Process(lexer::Lexer& lexer);
+};
+} // namespace parser::states::keywords

--- a/include/parser/states/keywords/pre.hpp
+++ b/include/parser/states/keywords/pre.hpp
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "parser/states/types/array.hpp"
+
+namespace parser::states::keywords
+{
+/**
+ * @brief A "Pre" state of the parser, used to parse !pre keyword
+ * 
+ */
+class Pre : public types::Array
+{
+public:
+	/**
+     * @brief Construct a new Pre object
+     * 
+     * @param mediator - the associated parser's mediator
+     */
+	explicit Pre(Mediator& mediator);
+
+public:
+	/**
+     * @brief Process the input from the lexer
+     * 
+     * @param lexer - the lexer which handles tokenization of the input file
+     */
+	void Process(lexer::Lexer& lexer);
+};
+} // namespace parser::states::keywords

--- a/include/parser/states/state.hpp
+++ b/include/parser/states/state.hpp
@@ -49,6 +49,14 @@ public:
 
 protected:
 	/**
+      * @brief Skip the separator tokens
+      * 
+      * @param lexer - the lexer to get tokens from
+      * @return std::unique_ptr<tokens::Token> - the token next to the separator
+      */
+	static std::unique_ptr<tokens::Token> SkipSeparators(lexer::Lexer& lexer);
+
+	/**
       * @brief Match the token with the given punctuator type
       * 
       * @param token - the token to check

--- a/include/parser/tokens/separator.hpp
+++ b/include/parser/tokens/separator.hpp
@@ -17,32 +17,48 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#pragma once
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
+#include <cstdint>
+#include <map>
 
-namespace lexer
+#include "parser/tokens/token.hpp"
+
+namespace parser::tokens
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
+/**
+ * @brief The token that represents a separator
+ * 
+ */
+struct Separator : public Token
 {
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
+	/**
+	 * @brief The punctuator's type
+	 * 
+	 */
+	enum class Type : uint8_t
+	{
+		kSpace
+	};
 
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
-}
+	/**
+	 * @brief Construct a new Separator object
+	 * 
+	 * @param value_ - the string value of the token
+	 * @param type_ - punctuator's type
+	 */
+	explicit Separator(std::string value_, Type type_);
 
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
+	/**
+	 * @brief Current punctuator's type
+	 * 
+	 */
+	const Type type;
 
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+	/**
+     * @brief Mapping the input to the predefined set of punctuator types
+     * 
+     */
+	static const std::map<char, Type> kSeparatorToTypeMap;
+};
+} // namespace parser::tokens

--- a/include/scheduler/exceptions/postcompilationcommandexception.hpp
+++ b/include/scheduler/exceptions/postcompilationcommandexception.hpp
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace scheduler::exceptions
+{
+/**
+ * @brief An exception, used to notify that one of the commands failed
+ * 
+ */
+class PostCompilationCommandException : public std::runtime_error
+{
+public:
+	/**
+	 * @brief Construct a new PostCompilationCommandException object
+	 * 
+	 * @param command - the command that caused the error
+	 */
+	explicit PostCompilationCommandException(std::string command);
+
+protected:
+	/**
+	 * @brief The message, seeing on the exception occurence
+	 * 
+	 */
+	static const std::string kMessage;
+};
+} // namespace scheduler::exceptions

--- a/include/scheduler/exceptions/precompilationcommandexception.hpp
+++ b/include/scheduler/exceptions/precompilationcommandexception.hpp
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace scheduler::exceptions
+{
+/**
+ * @brief An exception, used to notify that one of the commands failed
+ * 
+ */
+class PreCompilationCommandException : public std::runtime_error
+{
+public:
+	/**
+	 * @brief Construct a new PreCompilationCommandException object
+	 * 
+	 * @param command - the command that caused the error
+	 */
+	explicit PreCompilationCommandException(std::string command);
+
+protected:
+	/**
+	 * @brief The message, seeing on the exception occurence
+	 * 
+	 */
+	static const std::string kMessage;
+};
+} // namespace scheduler::exceptions

--- a/include/scheduler/pipeline/job.hpp
+++ b/include/scheduler/pipeline/job.hpp
@@ -123,6 +123,21 @@ public:
 	 */
 	const std::string& GetCompilationFlags() const;
 
+	/**
+	 * @brief Set the pre-compilation command to run
+	 * 
+	 * @param value - the command to run
+	 */
+	void SetPreCompilationCommands(std::vector<std::string> value);
+
+	/**
+	 * @brief Get the pre-compilation command
+	 * 
+	 * @return const std::string& - the value of the flags
+	 */
+
+	const std::vector<std::string>& GetPreCompilationCommands() const;
+
 protected:
 	/**
 	 * @brief Job's name
@@ -153,5 +168,11 @@ protected:
 	 * 
 	 */
 	std::string cflags_;
+
+	/**
+	 * @brief Pre-compilation command
+	 * 
+	 */
+	std::vector<std::string> pre_commands_;
 };
 } // namespace scheduler::pipeline

--- a/include/scheduler/pipeline/job.hpp
+++ b/include/scheduler/pipeline/job.hpp
@@ -138,6 +138,21 @@ public:
 
 	const std::vector<std::string>& GetPreCompilationCommands() const;
 
+	/**
+	 * @brief Set the post-compilation command to run
+	 * 
+	 * @param value - the command to run
+	 */
+	void SetPostCompilationCommands(std::vector<std::string> value);
+
+	/**
+	 * @brief Get the post-compilation command
+	 * 
+	 * @return const std::string& - the value of the flags
+	 */
+
+	const std::vector<std::string>& GetPostCompilationCommands() const;
+
 protected:
 	/**
 	 * @brief Job's name
@@ -174,5 +189,11 @@ protected:
 	 * 
 	 */
 	std::vector<std::string> pre_commands_;
+
+	/**
+	 * @brief Post-compilation command
+	 * 
+	 */
+	std::vector<std::string> post_commands_;
 };
 } // namespace scheduler::pipeline

--- a/include/sys/nix/command.hpp
+++ b/include/sys/nix/command.hpp
@@ -35,6 +35,13 @@ public:
 	/**
      * @brief Construct a new Command object
      * 
+     * @param line - the line to run
+     */
+	explicit Command(std::string line);
+
+	/**
+     * @brief Construct a new Command object
+     * 
      * @param program - the program to run
      * @param parameters - the parameters to pass to the program
      */
@@ -50,15 +57,9 @@ public:
 
 protected:
 	/**
-     * @brief The program to run
+     * @brief The command
      * 
      */
-	std::string program_;
-
-	/**
-     * @brief The parameters to pass to the program
-     * 
-     */
-	std::string parameters_;
+	const std::string command_;
 };
 } // namespace sys::nix

--- a/src/lexer/scanner.cpp
+++ b/src/lexer/scanner.cpp
@@ -111,7 +111,7 @@ const lexer::Context& Scanner::GetContext() const
 void Scanner::Skip()
 {
 	// Read the next line if scanner finds a new line symbol, a comment or an empty line
-	auto character = SkipWhitespaces(context_.GetCharacter());
+	auto character = context_.GetCharacter();
 	while(!character || character.value() == constants::kComment)
 	{
 		std::string line;
@@ -126,24 +126,10 @@ void Scanner::Skip()
 		character = context_.GetCharacter();
 	}
 
-	// Skip while there is a whitespace or a tab
-	character = SkipWhitespaces(character);
-
 	// Check if the line still has anything to read
 	if(!character || character.value() == '\0')
 	{
 		file_.close();
 	}
-}
-
-std::optional<char> Scanner::SkipWhitespaces(std::optional<char> character)
-{
-	while(character && std::isspace(character.value()))
-	{
-		context_.Next();
-		character = context_.GetCharacter();
-	}
-
-	return character;
 }
 } // namespace lexer

--- a/src/parser/states/keyword.cpp
+++ b/src/parser/states/keyword.cpp
@@ -24,6 +24,7 @@
 #include "parser/states/keywords/cflags.hpp"
 #include "parser/states/keywords/deps.hpp"
 #include "parser/states/keywords/files.hpp"
+#include "parser/states/keywords/post.hpp"
 #include "parser/states/keywords/pre.hpp"
 #include "parser/states/keywords/project.hpp"
 
@@ -67,6 +68,11 @@ void Keyword::Process(lexer::Lexer& lexer)
 	else if(keyword == "pre")
 	{
 		mediator_.SetState(std::make_unique<keywords::Pre>(mediator_));
+		return;
+	}
+	else if(keyword == "post")
+	{
+		mediator_.SetState(std::make_unique<keywords::Post>(mediator_));
 		return;
 	}
 

--- a/src/parser/states/keyword.cpp
+++ b/src/parser/states/keyword.cpp
@@ -24,6 +24,7 @@
 #include "parser/states/keywords/cflags.hpp"
 #include "parser/states/keywords/deps.hpp"
 #include "parser/states/keywords/files.hpp"
+#include "parser/states/keywords/pre.hpp"
 #include "parser/states/keywords/project.hpp"
 
 namespace parser::states
@@ -61,6 +62,11 @@ void Keyword::Process(lexer::Lexer& lexer)
 	else if(keyword == "prj")
 	{
 		mediator_.SetState(std::make_unique<keywords::Project>(mediator_));
+		return;
+	}
+	else if(keyword == "pre")
+	{
+		mediator_.SetState(std::make_unique<keywords::Pre>(mediator_));
 		return;
 	}
 

--- a/src/parser/states/keywords/post.cpp
+++ b/src/parser/states/keywords/post.cpp
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "parser/states/keywords/post.hpp"
+
+#include "parser/states/statement.hpp"
+
+namespace parser::states::keywords
+{
+Post::Post(Mediator& mediator)
+	: Array{mediator}
+{}
+
+void Post::Process(lexer::Lexer& lexer)
+{
+	Array::Process(lexer);
+
+	// Set the compilation flags
+	auto& job = mediator_.BorrowJob();
+	job.SetPostCompilationCommands(std::move(GetValue()));
+
+	// Return to the Statement state
+	mediator_.SetState(std::make_unique<Statement>(mediator_));
+}
+} // namespace parser::states::keywords

--- a/src/parser/states/keywords/pre.cpp
+++ b/src/parser/states/keywords/pre.cpp
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "parser/states/keywords/pre.hpp"
+
+#include "parser/states/statement.hpp"
+
+namespace parser::states::keywords
+{
+Pre::Pre(Mediator& mediator)
+	: Array{mediator}
+{}
+
+void Pre::Process(lexer::Lexer& lexer)
+{
+	Array::Process(lexer);
+
+	// Set the compilation flags
+	auto& job = mediator_.BorrowJob();
+	job.SetPreCompilationCommands(std::move(GetValue()));
+
+	// Return to the Statement state
+	mediator_.SetState(std::make_unique<Statement>(mediator_));
+}
+} // namespace parser::states::keywords

--- a/src/parser/states/state.cpp
+++ b/src/parser/states/state.cpp
@@ -20,12 +20,33 @@
 #include "parser/states/state.hpp"
 
 #include "parser/exceptions/unexpectedtokenexception.hpp"
+#include "parser/tokens/separator.hpp"
 
 namespace parser::states
 {
 State::State(Mediator& mediator)
 	: mediator_{mediator}
 {}
+
+std::unique_ptr<tokens::Token> State::SkipSeparators(lexer::Lexer& lexer)
+{
+	std::unique_ptr<tokens::Token> token;
+	while((token = lexer.Next()))
+	{
+		// Token might be nullptr, handle this case
+		if(!token)
+		{
+			throw std::runtime_error("State::SkipSeparators() was called with nullptr.");
+		}
+
+		if(!dynamic_cast<tokens::Separator*>(token.get()))
+		{
+			break;
+		}
+	}
+
+	return token;
+}
 
 void State::Match(std::unique_ptr<tokens::Token> token, tokens::Punctuator::Type value)
 {

--- a/src/parser/states/statement.cpp
+++ b/src/parser/states/statement.cpp
@@ -30,7 +30,7 @@ Statement::Statement(Mediator& mediator)
 void Statement::Process(lexer::Lexer& lexer)
 {
 	// Check if the token to process is present
-	auto token = lexer.Next();
+	auto token = State::SkipSeparators(lexer);
 	if(!token)
 	{
 		mediator_.SetState({});

--- a/src/parser/states/types/array.cpp
+++ b/src/parser/states/types/array.cpp
@@ -30,10 +30,13 @@ Array::Array(Mediator& mediator)
 
 void Array::Process(lexer::Lexer& lexer)
 {
-	Match(lexer.Next(), tokens::Punctuator::Type::kLeftSquareBracket);
+	// Skip separators in between the keyword and the
+	auto token = SkipSeparators(lexer);
+
+	// Expect the bracket at the start of the string
+	Match(std::move(token), tokens::Punctuator::Type::kLeftSquareBracket);
 
 	tokens::Punctuator::Type type;
-	std::unique_ptr<tokens::Token> terminator;
 	do
 	{
 		// Get the next string
@@ -42,23 +45,23 @@ void Array::Process(lexer::Lexer& lexer)
 		String::Clear();
 
 		// Get the terminator token
-		terminator = lexer.Next();
-		if(!terminator)
+		token = lexer.Next();
+		if(!token)
 		{
 			throw exceptions::UnexpectedEndOfFileException(lexer.GetContext());
 		}
 
 		// Get the type of the terminator
-		auto ptr = dynamic_cast<tokens::Punctuator*>(terminator.get());
+		auto ptr = dynamic_cast<tokens::Punctuator*>(token.get());
 		if(!ptr)
 		{
-			throw exceptions::UnexpectedTokenException(std::move(terminator->value));
+			throw exceptions::UnexpectedTokenException(std::move(token->value));
 		}
 		type = ptr->type;
 
 	} while(type == tokens::Punctuator::Type::kComma);
 
-	Match(std::move(terminator), tokens::Punctuator::Type::kRightSquareBracket);
+	Match(std::move(token), tokens::Punctuator::Type::kRightSquareBracket);
 }
 
 std::vector<std::string> Array::GetValue() const

--- a/src/parser/states/types/string.cpp
+++ b/src/parser/states/types/string.cpp
@@ -29,9 +29,13 @@ String::String(Mediator& mediator)
 
 void String::Process(lexer::Lexer& lexer)
 {
-	Match(lexer.Next(), ::parser::tokens::Punctuator::Type::kDoubleQuoteMark);
+	// Skip separators in between the keyword and the
+	auto token = State::SkipSeparators(lexer);
 
-	std::unique_ptr<tokens::Token> token;
+	// Expect the double quote mark at the start of the string
+	Match(std::move(token), ::parser::tokens::Punctuator::Type::kDoubleQuoteMark);
+
+	// Add tokens one by one to the internal buffer
 	while((token = lexer.Next()))
 	{
 		const auto value = std::move(token->value);

--- a/src/parser/tokens/separator.cpp
+++ b/src/parser/tokens/separator.cpp
@@ -17,32 +17,14 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#include "parser/tokens/separator.hpp"
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
-
-namespace lexer
+namespace parser::tokens
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
-{
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
+const std::map<char, Separator::Type> Separator::kSeparatorToTypeMap{{' ', Type::kSpace}};
 
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
-}
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+Separator::Separator(std::string value_, Type type_)
+	: Token{std::move(value_)}
+	, type{type_}
+{}
+} // namespace parser::tokens

--- a/src/scheduler/exceptions/postcompilationcommandexception.cpp
+++ b/src/scheduler/exceptions/postcompilationcommandexception.cpp
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "scheduler/exceptions/postcompilationcommandexception.hpp"
+
+namespace scheduler::exceptions
+{
+const std::string PostCompilationCommandException::kMessage{"The following command failed: "};
+
+PostCompilationCommandException::PostCompilationCommandException(std::string command)
+	: std::runtime_error(kMessage + command)
+{}
+} // namespace scheduler::exceptions

--- a/src/scheduler/exceptions/precompilationcommandexception.cpp
+++ b/src/scheduler/exceptions/precompilationcommandexception.cpp
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,24 +17,13 @@
  * under the License.
  */
 
-#include "sys/nix/command.hpp"
+#include "scheduler/exceptions/precompilationcommandexception.hpp"
 
-bool result = true;
+namespace scheduler::exceptions
+{
+const std::string PreCompilationCommandException::kMessage{"The following command failed: "};
 
-namespace sys::nix
-{
-Command::Command(std::string line)
-{
-	// noop
-}
-
-Command::Command(std::string program, std::string parameters)
-{
-	// noop
-}
-
-bool Command::Execute()
-{
-	return result;
-}
-} // namespace sys::nix
+PreCompilationCommandException::PreCompilationCommandException(std::string command)
+	: std::runtime_error(kMessage + command)
+{}
+} // namespace scheduler::exceptions

--- a/src/scheduler/pipeline/job.cpp
+++ b/src/scheduler/pipeline/job.cpp
@@ -31,6 +31,7 @@ Job::Job(Job&& other) noexcept
 	, files_{std::move(other.files_)}
 	, dependencies_{std::move(other.dependencies_)}
 	, cflags_{std::move(other.cflags_)}
+	, pre_commands_{std::move(other.pre_commands_)}
 {}
 
 const std::string& Job::GetProjectName() const
@@ -76,5 +77,15 @@ void Job::SetCompilationFlags(std::string value)
 const std::string& Job::GetCompilationFlags() const
 {
 	return cflags_;
+}
+
+void Job::SetPreCompilationCommands(std::vector<std::string> value)
+{
+	pre_commands_ = std::move(value);
+}
+
+const std::vector<std::string>& Job::GetPreCompilationCommands() const
+{
+	return pre_commands_;
 }
 } // namespace scheduler::pipeline

--- a/src/scheduler/pipeline/job.cpp
+++ b/src/scheduler/pipeline/job.cpp
@@ -32,6 +32,7 @@ Job::Job(Job&& other) noexcept
 	, dependencies_{std::move(other.dependencies_)}
 	, cflags_{std::move(other.cflags_)}
 	, pre_commands_{std::move(other.pre_commands_)}
+	, post_commands_{std::move(other.post_commands_)}
 {}
 
 const std::string& Job::GetProjectName() const
@@ -87,5 +88,15 @@ void Job::SetPreCompilationCommands(std::vector<std::string> value)
 const std::vector<std::string>& Job::GetPreCompilationCommands() const
 {
 	return pre_commands_;
+}
+
+void Job::SetPostCompilationCommands(std::vector<std::string> value)
+{
+	post_commands_ = std::move(value);
+}
+
+const std::vector<std::string>& Job::GetPostCompilationCommands() const
+{
+	return post_commands_;
 }
 } // namespace scheduler::pipeline

--- a/src/scheduler/pipeline/pipeline.cpp
+++ b/src/scheduler/pipeline/pipeline.cpp
@@ -29,6 +29,7 @@
 
 #include "scheduler/exceptions/compilationerrorexception.hpp"
 #include "scheduler/exceptions/linkerrorexception.hpp"
+#include "scheduler/exceptions/postcompilationcommandexception.hpp"
 #include "scheduler/exceptions/precompilationcommandexception.hpp"
 
 namespace scheduler::pipeline
@@ -77,6 +78,16 @@ void Pipeline::Run() const
 	if(!command.Execute())
 	{
 		throw exceptions::LinkErrorException(job_.GetProjectName());
+	}
+
+	// Execute post-compilation commands
+	for(const auto& line : job_.GetPostCompilationCommands())
+	{
+		Command command{line};
+		if(command.Execute())
+		{
+			throw exceptions::PostCompilationCommandException(line);
+		}
 	}
 }
 

--- a/src/scheduler/pipeline/pipeline.cpp
+++ b/src/scheduler/pipeline/pipeline.cpp
@@ -29,6 +29,7 @@
 
 #include "scheduler/exceptions/compilationerrorexception.hpp"
 #include "scheduler/exceptions/linkerrorexception.hpp"
+#include "scheduler/exceptions/precompilationcommandexception.hpp"
 
 namespace scheduler::pipeline
 {
@@ -46,6 +47,16 @@ void Pipeline::Run() const
 	// Create the directory for the output
 	const std::filesystem::path folder{job_.GetProjectName()};
 	std::filesystem::create_directory(folder);
+
+	// Execute pre-compilation commands
+	for(const auto& line : job_.GetPreCompilationCommands())
+	{
+		Command command{line};
+		if(command.Execute())
+		{
+			throw exceptions::PreCompilationCommandException(line);
+		}
+	}
 
 	std::stringstream parameters{};
 	for(const auto& file : job_.GetFiles())

--- a/src/sys/nix/command.cpp
+++ b/src/sys/nix/command.cpp
@@ -24,17 +24,16 @@
 
 namespace sys::nix
 {
+Command::Command(std::string line)
+	: command_{line}
+{}
+
 Command::Command(std::string program, std::string parameters)
-	: program_{program}
-	, parameters_{parameters}
+	: command_{std::move(program + " " + parameters)}
 {}
 
 bool Command::Execute()
 {
-	// Prepare the command
-	std::stringstream command;
-	command << program_ << " " << parameters_;
-
-	return std::system(command.str().c_str()) == 0;
+	return std::system(command_.c_str()) == 0;
 }
 } // namespace sys::nix

--- a/tests/lexer/handlers/separatorhandler/CMakeLists.txt
+++ b/tests/lexer/handlers/separatorhandler/CMakeLists.txt
@@ -17,7 +17,38 @@
 # under the License.
 #
 
-add_subdirectory(handler)
-add_subdirectory(punctuatorhandler)
-add_subdirectory(separatorhandler)
-add_subdirectory(wordhandler)
+project("separatorhandler")
+
+set(SOURCES 
+    ${CMAKE_SOURCE_DIR}/src/lexer/handlers/separatorhandler.cpp
+)
+
+set(STUBS
+    ${STUBS_FOLDER}/lexer/exceptions/fileemptyexception.cpp
+    ${STUBS_FOLDER}/lexer/exceptions/filenotfoundexception.cpp
+    ${STUBS_FOLDER}/lexer/exceptions/unexpectedlexemeexception.cpp
+    ${STUBS_FOLDER}/lexer/context.cpp
+
+    src/stubs/lexer/handlers/handler.cpp
+    src/stubs/lexer/scanner.cpp
+    src/stubs/parser/tokens/token.cpp
+    src/stubs/parser/tokens/separator.cpp
+)
+
+add_executable(${PROJECT_NAME} 
+    ${SOURCES}
+    ${STUBS}
+
+    src/main.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    include
+)
+
+target_link_libraries(${PROJECT_NAME} 
+    gmock
+    gmock_main
+)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/lexer/handlers/separatorhandler/include/mocks/lexer/handlers/handler.hpp
+++ b/tests/lexer/handlers/separatorhandler/include/mocks/lexer/handlers/handler.hpp
@@ -17,32 +17,22 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#pragma once
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
+#include <gmock/gmock.h>
 
-namespace lexer
+#include "lexer/handlers/handler.hpp"
+#include "lexer/scanner.hpp"
+#include "parser/tokens/token.hpp"
+
+namespace mocks::lexer::handlers
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
+class Handler : public ::lexer::handlers::Handler
 {
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
-
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
-}
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+public:
+	MOCK_METHOD(std::unique_ptr<::parser::tokens::Token>,
+				Process,
+				(::lexer::Scanner&),
+				(const, override));
+};
+} // namespace mocks::lexer::handlers

--- a/tests/lexer/handlers/separatorhandler/src/main.cpp
+++ b/tests/lexer/handlers/separatorhandler/src/main.cpp
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <filesystem>
+
+#include <gtest/gtest.h>
+
+#include "lexer/exceptions/unexpectedlexemeexception.hpp"
+#include "lexer/handlers/separatorhandler.hpp"
+
+#include "mocks/lexer/handlers/handler.hpp"
+
+namespace fs = std::filesystem;
+namespace lex = ::lexer;
+namespace exc = ::lexer::exceptions;
+
+/**
+ * @brief Test fixture class for the SeparatorHandler component testing
+ * 
+ */
+class SeparatorHandlerTest : public ::testing::Test
+{
+protected:
+	/**
+	 * @brief Set up the test fixture
+	 * 
+	 */
+	void SetUp() override
+	{
+		if(fs::exists(kFilePath) && !fs::is_regular_file(kFilePath))
+		{
+			FAIL() << "The node " << kFilePath << " is not a regular file.";
+		}
+
+		file.open(kFilePath, std::ofstream::trunc);
+		if(!file.is_open())
+		{
+			FAIL() << "Couldn't open the file " << kFilePath << ".";
+		}
+	}
+
+	/**
+	 * @brief Tear down the test fixture
+	 * 
+	 */
+	void TearDown() override
+	{
+		file.close();
+	}
+
+protected:
+	/**
+	 * @brief The default file path, used by the test suite
+	 * 
+	 */
+	static const fs::path kFilePath;
+
+	/**
+	 * @brief The test file handle
+	 * 
+	 */
+	std::ofstream file;
+
+	/**
+	 * @brief The instance to test
+	 * 
+	 */
+	lexer::handlers::SeparatorHandler instance_;
+};
+
+const fs::path SeparatorHandlerTest::kFilePath{"build.bbs"};
+
+/**
+ * @brief Check if the end of the file is handled properly by the handler
+ * 
+ */
+TEST_F(SeparatorHandlerTest, TestProcessNullopt)
+{
+	using ::testing::_;
+
+	// Create a mock to check if the next handler is called
+	const auto mock = new mocks::lexer::handlers::Handler();
+	instance_.SetNext(std::unique_ptr<lex::handlers::Handler>(mock));
+
+	// Expect the mock to be called
+	lex::Scanner scanner{kFilePath};
+	EXPECT_NO_THROW(instance_.Process(scanner));
+	EXPECT_CALL(*mock, Process(_));
+
+	// Allow leak since the pointer will be deleted by the unique_ptr wrapper
+	testing::Mock::AllowLeak(mock);
+}
+
+/**
+ * @brief Check if the handler correctly reacts on an unexpected lexeme
+ * 
+ */
+TEST_F(SeparatorHandlerTest, TestProcessNextNullptr)
+{
+	using ::testing::_;
+
+	// Write an unexpected lexeme to the file
+	file << 'a' << std::endl;
+
+	// Create a mock to check if the next handler is called
+	const auto mock = new mocks::lexer::handlers::Handler();
+	instance_.SetNext(std::unique_ptr<lex::handlers::Handler>(mock));
+
+	lex::Scanner scanner{kFilePath};
+	EXPECT_NO_THROW(instance_.Process(scanner));
+	EXPECT_CALL(*mock, Process(_));
+
+	// Allow leak since the pointer will be deleted by the unique_ptr wrapper
+	testing::Mock::AllowLeak(mock);
+}
+
+/**
+ * @brief Check if the valid character triggers a call to the next handler's Process() function
+ * 
+ */
+TEST_F(SeparatorHandlerTest, TestProcess)
+{
+	namespace handlers = lexer::handlers;
+
+	// Add some valid text to the file
+	for(auto [key, value] : parser::tokens::Separator::kSeparatorToTypeMap)
+	{
+		file << key;
+	}
+	file << std::endl;
+
+	// Check every separator from the map
+	lex::Scanner scanner{kFilePath};
+	std::unique_ptr<parser::tokens::Token> token;
+	while(token = instance_.Process(scanner))
+	{
+		const auto character = token->value.at(0);
+		EXPECT_NE(parser::tokens::Separator::kSeparatorToTypeMap.find(character),
+				  parser::tokens::Separator::kSeparatorToTypeMap.end());
+	}
+}

--- a/tests/lexer/handlers/separatorhandler/src/stubs/lexer/handlers/handler.cpp
+++ b/tests/lexer/handlers/separatorhandler/src/stubs/lexer/handlers/handler.cpp
@@ -17,32 +17,19 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#include "lexer/handlers/handler.hpp"
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
+#include "lexer/exceptions/unexpectedlexemeexception.hpp"
 
-namespace lexer
+namespace lexer::handlers
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
+std::unique_ptr<Handler::Token> Handler::Process(Scanner& scanner) const
 {
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
-
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
+	return {};
 }
 
-const Context& Lexer::GetContext() const
+void Handler::SetNext(std::unique_ptr<Handler> next)
 {
-	return scanner_.GetContext();
+	next_ = std::move(next);
 }
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+} // namespace lexer::handlers

--- a/tests/lexer/handlers/separatorhandler/src/stubs/lexer/scanner.cpp
+++ b/tests/lexer/handlers/separatorhandler/src/stubs/lexer/scanner.cpp
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "lexer/scanner.hpp"
+
+#include "lexer/exceptions/filenotfoundexception.hpp"
+
+namespace lexer
+{
+Scanner::Scanner(const std::filesystem::path& path)
+{
+	file_.open(path);
+	if(!file_.is_open())
+	{
+		throw exceptions::FileNotFoundException(path);
+	}
+
+	// Get the first line from file and initialize the iterator
+	std::string line;
+	std::getline(file_, line);
+	context_.Update(std::move(line));
+}
+
+Scanner::~Scanner()
+{
+	// Close the file
+	if(file_.is_open())
+	{
+		file_.close();
+	}
+}
+
+std::optional<char> Scanner::Get()
+{
+	// Don't return anything if the file is closed
+	if(!file_.is_open())
+	{
+		return {};
+	}
+
+	return context_.GetCharacter();
+}
+
+void Scanner::Move()
+{
+	// Don't return anything if the file is closed
+	if(!file_.is_open())
+	{
+		return;
+	}
+
+	context_.Next();
+}
+
+const lexer::Context& Scanner::GetContext() const
+{
+	return context_;
+}
+
+void Scanner::Skip()
+{
+	// noop
+}
+} // namespace lexer

--- a/tests/lexer/handlers/separatorhandler/src/stubs/parser/tokens/separator.cpp
+++ b/tests/lexer/handlers/separatorhandler/src/stubs/parser/tokens/separator.cpp
@@ -17,32 +17,14 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#include "parser/tokens/separator.hpp"
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
-
-namespace lexer
+namespace parser::tokens
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
-{
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
+const std::map<char, Separator::Type> Separator::kSeparatorToTypeMap{{' ', Type::kSpace}};
 
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
-}
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+Separator::Separator(std::string value_, Type type_)
+	: Token{std::move(value_)}
+	, type{type_}
+{}
+} // namespace parser::tokens

--- a/tests/lexer/handlers/separatorhandler/src/stubs/parser/tokens/token.cpp
+++ b/tests/lexer/handlers/separatorhandler/src/stubs/parser/tokens/token.cpp
@@ -17,32 +17,11 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#include "parser/tokens/token.hpp"
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
-
-namespace lexer
+namespace parser::tokens
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
-{
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
-
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
-}
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+Token::Token(std::string value_)
+	: value{std::move(value_)}
+{}
+} // namespace parser::tokens

--- a/tests/lexer/lexer/CMakeLists.txt
+++ b/tests/lexer/lexer/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
 set(STUBS
     ${STUBS_FOLDER}/lexer/handlers/handler.cpp
     ${STUBS_FOLDER}/lexer/handlers/punctuatorhandler.cpp
+    ${STUBS_FOLDER}/lexer/handlers/separatorhandler.cpp
     ${STUBS_FOLDER}/lexer/handlers/wordhandler.cpp
     ${STUBS_FOLDER}/lexer/scanner.cpp
 )

--- a/tests/lexer/scanner/src/main.cpp
+++ b/tests/lexer/scanner/src/main.cpp
@@ -132,36 +132,6 @@ TEST_F(ScannerTest, TestConstructorEmptyFile)
 }
 
 /**
- * @brief Check if the Scanner component skips whitespaces
- * 
- */
-TEST_F(ScannerTest, TestGetWhitespacePrefix)
-{
-	const std::string data{"Hello World!"};
-
-	// Write some test data to the file with a tab prefix
-	file << std::string(10, ' ') << data << std::endl;
-
-	fake::Scanner instance{kFilePath};
-	EXPECT_EQ(instance.Get(), data.at(0));
-}
-
-/**
- * @brief Check if the Scanner component skips tabs
- * 
- */
-TEST_F(ScannerTest, TestGetTabPrefix)
-{
-	const std::string data{"Hello World!"};
-
-	// Write some test data to the file with a whitespace prefix
-	file << std::string(10, '\t') << data << std::endl;
-
-	fake::Scanner instance{kFilePath};
-	EXPECT_EQ(instance.Get(), data.at(0));
-}
-
-/**
  * @brief Check if the Scanner component reads the next line if it is the end of the current line
  * 
  */

--- a/tests/parser/states/keyword/src/main.cpp
+++ b/tests/parser/states/keyword/src/main.cpp
@@ -26,6 +26,7 @@
 #include "parser/parser.hpp"
 #include "parser/states/keywords/deps.hpp"
 #include "parser/states/keywords/files.hpp"
+#include "parser/states/keywords/pre.hpp"
 #include "parser/states/keywords/project.hpp"
 
 #include "aux/handlers/dummyhandler.hpp"
@@ -129,7 +130,7 @@ TEST_F(KeywordTest, TestProcessFilesKeyword)
 }
 
 /**
- * @brief Check if the Process() method correctly handles the "Files" keyword
+ * @brief Check if the Process() method correctly handles the "Deps" keyword
  * 
  */
 TEST_F(KeywordTest, TestProcessDepsKeyword)
@@ -143,4 +144,20 @@ TEST_F(KeywordTest, TestProcessDepsKeyword)
 	EXPECT_NO_THROW(instance_.Process(lexer));
 	EXPECT_TRUE(
 		dynamic_cast<parser::states::keywords::Deps*>(instance_.mediator_.GetState().get()));
+}
+
+/**
+ * @brief Check if the Process() method correctly handles the "Pre" keyword
+ * 
+ */
+TEST_F(KeywordTest, TestProcessPreKeyword)
+{
+	std::vector<std::unique_ptr<Token>> tokens{};
+	tokens.emplace_back(std::make_unique<Token>("pre"));
+
+	auto handler = std::make_unique<handlers::DummyHandler>(std::move(tokens));
+	fakes::lexer::Lexer lexer{kFilePath, std::move(handler)};
+
+	EXPECT_NO_THROW(instance_.Process(lexer));
+	EXPECT_TRUE(dynamic_cast<parser::states::keywords::Pre*>(instance_.mediator_.GetState().get()));
 }

--- a/tests/parser/states/keyword/src/stubs/parser/states/state.cpp
+++ b/tests/parser/states/keyword/src/stubs/parser/states/state.cpp
@@ -21,12 +21,33 @@
 
 #include "parser/exceptions/unexpectedtokenexception.hpp"
 #include "parser/mediator.hpp"
+#include "parser/tokens/separator.hpp"
 
 namespace parser::states
 {
 State::State(Mediator& mediator)
 	: mediator_{mediator}
 {}
+
+std::unique_ptr<tokens::Token> State::SkipSeparators(lexer::Lexer& lexer)
+{
+	std::unique_ptr<tokens::Token> token;
+	while((token = lexer.Next()))
+	{
+		// Token might be nullptr, handle this case
+		if(!token)
+		{
+			throw std::runtime_error("State::SkipSeparators() was called with nullptr.");
+		}
+
+		if(!dynamic_cast<tokens::Separator*>(token.get()))
+		{
+			break;
+		}
+	}
+
+	return token;
+}
 
 void State::Match(std::unique_ptr<tokens::Token> token, tokens::Punctuator::Type value)
 {

--- a/tests/parser/states/keywords/CMakeLists.txt
+++ b/tests/parser/states/keywords/CMakeLists.txt
@@ -20,5 +20,6 @@
 add_subdirectory(cflags)
 add_subdirectory(deps)
 add_subdirectory(files)
+add_subdirectory(post)
 add_subdirectory(pre)
 add_subdirectory(project)

--- a/tests/parser/states/keywords/CMakeLists.txt
+++ b/tests/parser/states/keywords/CMakeLists.txt
@@ -20,4 +20,5 @@
 add_subdirectory(cflags)
 add_subdirectory(deps)
 add_subdirectory(files)
+add_subdirectory(pre)
 add_subdirectory(project)

--- a/tests/parser/states/keywords/post/CMakeLists.txt
+++ b/tests/parser/states/keywords/post/CMakeLists.txt
@@ -17,35 +17,26 @@
 # under the License.
 #
 
-project("keyword")
+project("post")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/parser/states/keyword.cpp
+    ${CMAKE_SOURCE_DIR}/src/parser/states/keywords/post.cpp
 )
 
 set(STUBS
     ${STUBS_FOLDER}/lexer/handlers/handler.cpp
+    ${STUBS_FOLDER}/lexer/lexer.cpp
     ${STUBS_FOLDER}/lexer/scanner.cpp
-    ${STUBS_FOLDER}/parser/exceptions/unexpectedendoffileexception.cpp
-    ${STUBS_FOLDER}/parser/exceptions/unexpectedkeywordexception.cpp
     ${STUBS_FOLDER}/parser/exceptions/unexpectedtokenexception.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/cflags.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/deps.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/files.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/pre.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/post.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/project.cpp
     ${STUBS_FOLDER}/parser/states/types/array.cpp
     ${STUBS_FOLDER}/parser/states/types/string.cpp
+    ${STUBS_FOLDER}/parser/states/state.cpp
     ${STUBS_FOLDER}/parser/states/statement.cpp
     ${STUBS_FOLDER}/parser/tokens/punctuator.cpp
     ${STUBS_FOLDER}/parser/tokens/token.cpp
+    ${STUBS_FOLDER}/parser/mediator.cpp
+    ${STUBS_FOLDER}/parser/parser.cpp
     ${STUBS_FOLDER}/scheduler/pipeline/job.cpp
-    
-    src/stubs/lexer/lexer.cpp
-    src/stubs/parser/states/state.cpp
-    src/stubs/parser/mediator.cpp
-    src/stubs/parser/parser.cpp
 )
 
 add_executable(${PROJECT_NAME} 
@@ -53,10 +44,6 @@ add_executable(${PROJECT_NAME}
     ${STUBS}
 
     src/main.cpp
-)
-
-target_include_directories(${PROJECT_NAME} PUBLIC
-    include
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/parser/states/keywords/post/src/main.cpp
+++ b/tests/parser/states/keywords/post/src/main.cpp
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "lexer/lexer.hpp"
+#include "parser/mediator.hpp"
+#include "parser/states/keywords/post.hpp"
+
+namespace fs = std::filesystem;
+
+/**
+ * @brief A text fixture to test parser::states::keywords::Pre component
+ * 
+ */
+class PostTest : public ::testing::Test
+{
+protected:
+	/**
+	 * @brief The default file path, used by the test suite
+	 * 
+	 */
+	static const fs::path kFilePath;
+
+	/**
+	 * @brief A mediator instance
+	 * 
+	 */
+	parser::Mediator mediator_;
+
+	/**
+	 * @brief The instance to test
+	 * 
+	 */
+	parser::states::keywords::Post instance_{mediator_};
+};
+
+const fs::path PostTest::kFilePath{""};
+
+/**
+ * @brief Check if the Process() method correctly handles abscence of the leading bracket
+ * 
+ */
+TEST_F(PostTest, TestProcess)
+{
+	lexer::Lexer lexer{kFilePath};
+	EXPECT_NO_THROW(instance_.Process(lexer));
+}

--- a/tests/parser/states/keywords/pre/CMakeLists.txt
+++ b/tests/parser/states/keywords/pre/CMakeLists.txt
@@ -17,34 +17,26 @@
 # under the License.
 #
 
-project("keyword")
+project("pre")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/parser/states/keyword.cpp
+    ${CMAKE_SOURCE_DIR}/src/parser/states/keywords/pre.cpp
 )
 
 set(STUBS
     ${STUBS_FOLDER}/lexer/handlers/handler.cpp
+    ${STUBS_FOLDER}/lexer/lexer.cpp
     ${STUBS_FOLDER}/lexer/scanner.cpp
-    ${STUBS_FOLDER}/parser/exceptions/unexpectedendoffileexception.cpp
-    ${STUBS_FOLDER}/parser/exceptions/unexpectedkeywordexception.cpp
     ${STUBS_FOLDER}/parser/exceptions/unexpectedtokenexception.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/cflags.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/deps.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/files.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/pre.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/project.cpp
     ${STUBS_FOLDER}/parser/states/types/array.cpp
     ${STUBS_FOLDER}/parser/states/types/string.cpp
+    ${STUBS_FOLDER}/parser/states/state.cpp
     ${STUBS_FOLDER}/parser/states/statement.cpp
     ${STUBS_FOLDER}/parser/tokens/punctuator.cpp
     ${STUBS_FOLDER}/parser/tokens/token.cpp
+    ${STUBS_FOLDER}/parser/mediator.cpp
+    ${STUBS_FOLDER}/parser/parser.cpp
     ${STUBS_FOLDER}/scheduler/pipeline/job.cpp
-    
-    src/stubs/lexer/lexer.cpp
-    src/stubs/parser/states/state.cpp
-    src/stubs/parser/mediator.cpp
-    src/stubs/parser/parser.cpp
 )
 
 add_executable(${PROJECT_NAME} 
@@ -52,10 +44,6 @@ add_executable(${PROJECT_NAME}
     ${STUBS}
 
     src/main.cpp
-)
-
-target_include_directories(${PROJECT_NAME} PUBLIC
-    include
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/parser/states/keywords/pre/src/main.cpp
+++ b/tests/parser/states/keywords/pre/src/main.cpp
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "lexer/lexer.hpp"
+#include "parser/mediator.hpp"
+#include "parser/states/keywords/pre.hpp"
+
+namespace fs = std::filesystem;
+
+/**
+ * @brief A text fixture to test parser::states::keywords::Pre component
+ * 
+ */
+class PreTest : public ::testing::Test
+{
+protected:
+	/**
+	 * @brief The default file path, used by the test suite
+	 * 
+	 */
+	static const fs::path kFilePath;
+
+	/**
+	 * @brief A mediator instance
+	 * 
+	 */
+	parser::Mediator mediator_;
+
+	/**
+	 * @brief The instance to test
+	 * 
+	 */
+	parser::states::keywords::Pre instance_{mediator_};
+};
+
+const fs::path PreTest::kFilePath{""};
+
+/**
+ * @brief Check if the Process() method correctly handles abscence of the leading bracket
+ * 
+ */
+TEST_F(PreTest, TestProcess)
+{
+	lexer::Lexer lexer{kFilePath};
+	EXPECT_NO_THROW(instance_.Process(lexer));
+}

--- a/tests/parser/states/statement/src/stubs/parser/states/state.cpp
+++ b/tests/parser/states/statement/src/stubs/parser/states/state.cpp
@@ -21,12 +21,33 @@
 
 #include "parser/exceptions/unexpectedtokenexception.hpp"
 #include "parser/mediator.hpp"
+#include "parser/tokens/separator.hpp"
 
 namespace parser::states
 {
 State::State(Mediator& mediator)
 	: mediator_{mediator}
 {}
+
+std::unique_ptr<tokens::Token> State::SkipSeparators(lexer::Lexer& lexer)
+{
+	std::unique_ptr<tokens::Token> token;
+	while((token = lexer.Next()))
+	{
+		// Token might be nullptr, handle this case
+		if(!token)
+		{
+			throw std::runtime_error("State::SkipSeparators() was called with nullptr.");
+		}
+
+		if(!dynamic_cast<tokens::Separator*>(token.get()))
+		{
+			break;
+		}
+	}
+
+	return token;
+}
 
 void State::Match(std::unique_ptr<tokens::Token> token, tokens::Punctuator::Type value)
 {

--- a/tests/parser/states/types/array/src/stubs/parser/states/state.cpp
+++ b/tests/parser/states/types/array/src/stubs/parser/states/state.cpp
@@ -21,12 +21,33 @@
 
 #include "parser/exceptions/unexpectedtokenexception.hpp"
 #include "parser/mediator.hpp"
+#include "parser/tokens/separator.hpp"
 
 namespace parser::states
 {
 State::State(Mediator& mediator)
 	: mediator_{mediator}
 {}
+
+std::unique_ptr<tokens::Token> State::SkipSeparators(lexer::Lexer& lexer)
+{
+	std::unique_ptr<tokens::Token> token;
+	while((token = lexer.Next()))
+	{
+		// Token might be nullptr, handle this case
+		if(!token)
+		{
+			throw std::runtime_error("State::SkipSeparators() was called with nullptr.");
+		}
+
+		if(!dynamic_cast<tokens::Separator*>(token.get()))
+		{
+			break;
+		}
+	}
+
+	return token;
+}
 
 void State::Match(std::unique_ptr<tokens::Token> token, tokens::Punctuator::Type value)
 {

--- a/tests/parser/states/types/string/src/stubs/parser/states/state.cpp
+++ b/tests/parser/states/types/string/src/stubs/parser/states/state.cpp
@@ -21,12 +21,33 @@
 
 #include "parser/exceptions/unexpectedtokenexception.hpp"
 #include "parser/mediator.hpp"
+#include "parser/tokens/separator.hpp"
 
 namespace parser::states
 {
 State::State(Mediator& mediator)
 	: mediator_{mediator}
 {}
+
+std::unique_ptr<tokens::Token> State::SkipSeparators(lexer::Lexer& lexer)
+{
+	std::unique_ptr<tokens::Token> token;
+	while((token = lexer.Next()))
+	{
+		// Token might be nullptr, handle this case
+		if(!token)
+		{
+			throw std::runtime_error("State::SkipSeparators() was called with nullptr.");
+		}
+
+		if(!dynamic_cast<tokens::Separator*>(token.get()))
+		{
+			break;
+		}
+	}
+
+	return token;
+}
 
 void State::Match(std::unique_ptr<tokens::Token> token, tokens::Punctuator::Type value)
 {

--- a/tests/parser/tokens/CMakeLists.txt
+++ b/tests/parser/tokens/CMakeLists.txt
@@ -18,4 +18,5 @@
 #
 
 add_subdirectory(punctuator)
+add_subdirectory(separator)
 add_subdirectory(token)

--- a/tests/parser/tokens/separator/CMakeLists.txt
+++ b/tests/parser/tokens/separator/CMakeLists.txt
@@ -17,7 +17,21 @@
 # under the License.
 #
 
-add_subdirectory(handler)
-add_subdirectory(punctuatorhandler)
-add_subdirectory(separatorhandler)
-add_subdirectory(wordhandler)
+project("separator")
+
+set(SOURCES 
+    ${CMAKE_SOURCE_DIR}/src/parser/tokens/separator.cpp
+)
+
+set(STUBS
+    src/stubs/parser/tokens/token.cpp
+)
+
+add_executable(${PROJECT_NAME} 
+    ${SOURCES}
+    ${STUBS}
+
+    src/main.cpp
+)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/parser/tokens/separator/src/main.cpp
+++ b/tests/parser/tokens/separator/src/main.cpp
@@ -17,32 +17,23 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#include <gtest/gtest.h>
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
+#include "parser/tokens/separator.hpp"
 
-namespace lexer
+/**
+ * @brief Check if the constructor initializes the fields
+ * 
+ */
+TEST(SeparatorTest, TestConstructor)
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
-{
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
+	using Separator = parser::tokens::Separator;
+	using Type = Separator::Type;
 
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
+	const auto type = Type::kSpace;
+	const std::string data{" "};
+
+	Separator token{data, type};
+	EXPECT_EQ(token.value, data);
+	EXPECT_EQ(token.type, type);
 }
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer

--- a/tests/parser/tokens/separator/src/stubs/parser/tokens/token.cpp
+++ b/tests/parser/tokens/separator/src/stubs/parser/tokens/token.cpp
@@ -17,32 +17,11 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#include "parser/tokens/token.hpp"
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
-
-namespace lexer
+namespace parser::tokens
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
-{
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
-
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
-}
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+Token::Token(std::string value_)
+	: value{std::move(value_)}
+{}
+} // namespace parser::tokens

--- a/tests/scheduler/exceptions/CMakeLists.txt
+++ b/tests/scheduler/exceptions/CMakeLists.txt
@@ -19,4 +19,5 @@
 
 add_subdirectory(compilationerrorexception)
 add_subdirectory(linkerrorexception)
+add_subdirectory(postcompilationcommandexception)
 add_subdirectory(precompilationcommandexception)

--- a/tests/scheduler/exceptions/CMakeLists.txt
+++ b/tests/scheduler/exceptions/CMakeLists.txt
@@ -19,3 +19,4 @@
 
 add_subdirectory(compilationerrorexception)
 add_subdirectory(linkerrorexception)
+add_subdirectory(precompilationcommandexception)

--- a/tests/scheduler/exceptions/postcompilationcommandexception/CMakeLists.txt
+++ b/tests/scheduler/exceptions/postcompilationcommandexception/CMakeLists.txt
@@ -17,27 +17,20 @@
 # under the License.
 #
 
-project("pipeline")
+project("postcompilationcommandexception")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/scheduler/pipeline/pipeline.cpp
-)
-
-set(STUBS
-    ${STUBS_FOLDER}/scheduler/exceptions/compilationerrorexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/linkerrorexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/postcompilationcommandexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/precompilationcommandexception.cpp
-
-    src/stubs/scheduler/pipeline/job.cpp
-    src/stubs/sys/nix/command.cpp
+    ${CMAKE_SOURCE_DIR}/src/scheduler/exceptions/postcompilationcommandexception.cpp
 )
 
 add_executable(${PROJECT_NAME} 
     ${SOURCES}
-    ${STUBS}
 
     src/main.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    include
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/scheduler/exceptions/postcompilationcommandexception/include/fakes/scheduler/exceptions/postcompilationcommandexception.hpp
+++ b/tests/scheduler/exceptions/postcompilationcommandexception/include/fakes/scheduler/exceptions/postcompilationcommandexception.hpp
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "scheduler/exceptions/postcompilationcommandexception.hpp"
+
+namespace fakes::scheduler::exceptions
+{
+namespace exc = ::scheduler::exceptions;
+
+/**
+ * @brief An fake for the exception, used to notify that one of the commands failed
+ * 
+ */
+class PostCompilationCommandException : public exc::PostCompilationCommandException
+{
+public:
+	/**
+	 * @brief Construct a new PostCompilationCommandException object
+	 * 
+	 * @param command - the command that caused the error
+	 */
+	explicit PostCompilationCommandException(std::string command)
+		: exc::PostCompilationCommandException{command}
+	{}
+
+public:
+	using exc::PostCompilationCommandException::kMessage;
+};
+} // namespace fakes::scheduler::exceptions

--- a/tests/scheduler/exceptions/postcompilationcommandexception/src/main.cpp
+++ b/tests/scheduler/exceptions/postcompilationcommandexception/src/main.cpp
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fakes/scheduler/exceptions/postcompilationcommandexception.hpp"
+
+/**
+ * @brief Check if the exception is constructed with the correct message
+ * 
+ */
+TEST(PostCompilationCommandExceptionTest, TestConstructor)
+{
+	namespace exc = fakes::scheduler::exceptions;
+
+	const std::string command{"some-command"};
+	const exc::PostCompilationCommandException exception{command};
+	const auto data = exc::PostCompilationCommandException::kMessage + command;
+	EXPECT_STREQ(exception.what(), data.c_str());
+}

--- a/tests/scheduler/exceptions/precompilationcommandexception/CMakeLists.txt
+++ b/tests/scheduler/exceptions/precompilationcommandexception/CMakeLists.txt
@@ -17,26 +17,20 @@
 # under the License.
 #
 
-project("pipeline")
+project("precompilationcommandexception")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/scheduler/pipeline/pipeline.cpp
-)
-
-set(STUBS
-    ${STUBS_FOLDER}/scheduler/exceptions/compilationerrorexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/linkerrorexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/precompilationcommandexception.cpp
-
-    src/stubs/scheduler/pipeline/job.cpp
-    src/stubs/sys/nix/command.cpp
+    ${CMAKE_SOURCE_DIR}/src/scheduler/exceptions/precompilationcommandexception.cpp
 )
 
 add_executable(${PROJECT_NAME} 
     ${SOURCES}
-    ${STUBS}
 
     src/main.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    include
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/scheduler/exceptions/precompilationcommandexception/include/fakes/scheduler/exceptions/precompilationcommandexception.hpp
+++ b/tests/scheduler/exceptions/precompilationcommandexception/include/fakes/scheduler/exceptions/precompilationcommandexception.hpp
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "scheduler/exceptions/precompilationcommandexception.hpp"
+
+namespace fakes::scheduler::exceptions
+{
+namespace exc = ::scheduler::exceptions;
+
+/**
+ * @brief An fake for the exception, used to notify that one of the commands failed
+ * 
+ */
+class PreCompilationCommandException : public exc::PreCompilationCommandException
+{
+public:
+	/**
+	 * @brief Construct a new PreCompilationCommandException object
+	 * 
+	 * @param command - the command that caused the error
+	 */
+	explicit PreCompilationCommandException(std::string command)
+		: exc::PreCompilationCommandException{command}
+	{}
+
+public:
+	using exc::PreCompilationCommandException::kMessage;
+};
+} // namespace fakes::scheduler::exceptions

--- a/tests/scheduler/exceptions/precompilationcommandexception/src/main.cpp
+++ b/tests/scheduler/exceptions/precompilationcommandexception/src/main.cpp
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fakes/scheduler/exceptions/precompilationcommandexception.hpp"
+
+/**
+ * @brief Check if the exception is constructed with the correct message
+ * 
+ */
+TEST(PreCompilationCommandExceptionTest, TestConstructor)
+{
+	namespace exc = fakes::scheduler::exceptions;
+
+	const std::string command{"some-command"};
+	const exc::PreCompilationCommandException exception{command};
+	const auto data = exc::PreCompilationCommandException::kMessage + command;
+	EXPECT_STREQ(exception.what(), data.c_str());
+}

--- a/tests/scheduler/pipeline/job/src/main.cpp
+++ b/tests/scheduler/pipeline/job/src/main.cpp
@@ -109,3 +109,15 @@ TEST_F(JobTest, TestSetPreCompilationCommands)
 
 	EXPECT_EQ(instance_.GetPreCompilationCommands(), commands);
 }
+
+/**
+ * @brief Check if the GetPostCompilationCommands() method returns a reference to the correctly filled vector
+ * 
+ */
+TEST_F(JobTest, TestSetPostCompilationCommands)
+{
+	const std::vector<std::string> commands{"some_command"};
+	instance_.SetPostCompilationCommands(commands);
+
+	EXPECT_EQ(instance_.GetPostCompilationCommands(), commands);
+}

--- a/tests/scheduler/pipeline/job/src/main.cpp
+++ b/tests/scheduler/pipeline/job/src/main.cpp
@@ -97,3 +97,15 @@ TEST_F(JobTest, TestSetProjectPath)
 
 	EXPECT_EQ(instance_.GetProjectPath(), path);
 }
+
+/**
+ * @brief Check if the GetPreCompilationCommands() method returns a reference to the correctly filled vector
+ * 
+ */
+TEST_F(JobTest, TestSetPreCompilationCommands)
+{
+	const std::vector<std::string> commands{"some_command"};
+	instance_.SetPreCompilationCommands(commands);
+
+	EXPECT_EQ(instance_.GetPreCompilationCommands(), commands);
+}

--- a/tests/scheduler/pipeline/pipeline/src/stubs/scheduler/pipeline/job.cpp
+++ b/tests/scheduler/pipeline/pipeline/src/stubs/scheduler/pipeline/job.cpp
@@ -88,4 +88,14 @@ const std::vector<std::string>& Job::GetPreCompilationCommands() const
 {
 	return pre_commands_;
 }
+
+void Job::SetPostCompilationCommands(std::vector<std::string> value)
+{
+	post_commands_ = std::move(value);
+}
+
+const std::vector<std::string>& Job::GetPostCompilationCommands() const
+{
+	return post_commands_;
+}
 } // namespace scheduler::pipeline

--- a/tests/scheduler/pipeline/pipeline/src/stubs/scheduler/pipeline/job.cpp
+++ b/tests/scheduler/pipeline/pipeline/src/stubs/scheduler/pipeline/job.cpp
@@ -78,4 +78,14 @@ const std::string& Job::GetCompilationFlags() const
 {
 	return cflags_;
 }
+
+void Job::SetPreCompilationCommands(std::vector<std::string> value)
+{
+	pre_commands_ = std::move(value);
+}
+
+const std::vector<std::string>& Job::GetPreCompilationCommands() const
+{
+	return pre_commands_;
+}
 } // namespace scheduler::pipeline

--- a/tests/stubs/lexer/handlers/separatorhandler.cpp
+++ b/tests/stubs/lexer/handlers/separatorhandler.cpp
@@ -17,32 +17,13 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
-
-#include "lexer/handlers/punctuatorhandler.hpp"
 #include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
 
-namespace lexer
+namespace lexer::handlers
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
-{
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
 
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
+std::unique_ptr<SeparatorHandler::Token> SeparatorHandler::Process(Scanner& scanner) const
+{
+	return {};
 }
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+} // namespace lexer::handlers

--- a/tests/stubs/parser/states/keywords/post.cpp
+++ b/tests/stubs/parser/states/keywords/post.cpp
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "parser/states/keywords/post.hpp"
+
+#include "parser/states/statement.hpp"
+
+namespace parser::states::keywords
+{
+Post::Post(Mediator& mediator)
+	: Array{mediator}
+{}
+
+void Post::Process(lexer::Lexer& lexer)
+{
+	// noop
+}
+} // namespace parser::states::keywords

--- a/tests/stubs/parser/states/keywords/pre.cpp
+++ b/tests/stubs/parser/states/keywords/pre.cpp
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "parser/states/keywords/pre.hpp"
+
+#include "parser/states/statement.hpp"
+
+namespace parser::states::keywords
+{
+Pre::Pre(Mediator& mediator)
+	: Array{mediator}
+{}
+
+void Pre::Process(lexer::Lexer& lexer)
+{
+	// noop
+}
+} // namespace parser::states::keywords

--- a/tests/stubs/parser/states/state.cpp
+++ b/tests/stubs/parser/states/state.cpp
@@ -19,13 +19,18 @@
 
 #include "parser/states/state.hpp"
 
-#include "parser/parser.hpp"
+#include "parser/mediator.hpp"
 
 namespace parser::states
 {
 State::State(Mediator& mediator)
 	: mediator_{mediator}
 {}
+
+std::unique_ptr<tokens::Token> State::SkipSeparators(lexer::Lexer& lexer)
+{
+	return {};
+}
 
 void State::Match(std::unique_ptr<tokens::Token> token, tokens::Punctuator::Type value)
 {

--- a/tests/stubs/parser/tokens/separator.cpp
+++ b/tests/stubs/parser/tokens/separator.cpp
@@ -17,32 +17,14 @@
  * under the License.
  */
 
-#include "lexer/lexer.hpp"
+#include "parser/tokens/separator.hpp"
 
-#include "lexer/handlers/punctuatorhandler.hpp"
-#include "lexer/handlers/separatorhandler.hpp"
-#include "lexer/handlers/wordhandler.hpp"
-
-namespace lexer
+namespace parser::tokens
 {
-Lexer::Lexer(const std::filesystem::path& path)
-	: scanner_{path}
-{
-	auto word_handler = std::make_unique<handlers::WordHandler>();
-	word_handler->SetNext(std::make_unique<handlers::SeparatorHandler>());
+const std::map<char, Separator::Type> Separator::kSeparatorToTypeMap{};
 
-	// Set the main handler
-	handler_ = std::make_unique<handlers::PunctuatorHandler>();
-	handler_->SetNext(std::move(word_handler));
-}
-
-const Context& Lexer::GetContext() const
-{
-	return scanner_.GetContext();
-}
-
-std::unique_ptr<Lexer::Token> Lexer::Next()
-{
-	return handler_->Process(scanner_);
-}
-} // namespace lexer
+Separator::Separator(std::string value_, Type type_)
+	: Token{std::move(value_)}
+	, type{type_}
+{}
+} // namespace parser::tokens

--- a/tests/stubs/scheduler/exceptions/postcompilationcommandexception.cpp
+++ b/tests/stubs/scheduler/exceptions/postcompilationcommandexception.cpp
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "scheduler/exceptions/postcompilationcommandexception.hpp"
+
+namespace scheduler::exceptions
+{
+const std::string PostCompilationCommandException::kMessage{};
+
+PostCompilationCommandException::PostCompilationCommandException(std::string command)
+	: std::runtime_error(kMessage)
+{}
+} // namespace scheduler::exceptions

--- a/tests/stubs/scheduler/exceptions/precompilationcommandexception.cpp
+++ b/tests/stubs/scheduler/exceptions/precompilationcommandexception.cpp
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *  http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,24 +17,13 @@
  * under the License.
  */
 
-#include "sys/nix/command.hpp"
+#include "scheduler/exceptions/precompilationcommandexception.hpp"
 
-bool result = true;
+namespace scheduler::exceptions
+{
+const std::string PreCompilationCommandException::kMessage{};
 
-namespace sys::nix
-{
-Command::Command(std::string line)
-{
-	// noop
-}
-
-Command::Command(std::string program, std::string parameters)
-{
-	// noop
-}
-
-bool Command::Execute()
-{
-	return result;
-}
-} // namespace sys::nix
+PreCompilationCommandException::PreCompilationCommandException(std::string command)
+	: std::runtime_error(kMessage)
+{}
+} // namespace scheduler::exceptions

--- a/tests/stubs/scheduler/pipeline/job.cpp
+++ b/tests/stubs/scheduler/pipeline/job.cpp
@@ -85,4 +85,14 @@ const std::vector<std::string>& Job::GetPreCompilationCommands() const
 {
 	return pre_commands_;
 }
+
+void Job::SetPostCompilationCommands(std::vector<std::string> value)
+{
+	// noop
+}
+
+const std::vector<std::string>& Job::GetPostCompilationCommands() const
+{
+	return post_commands_;
+}
 } // namespace scheduler::pipeline

--- a/tests/stubs/scheduler/pipeline/job.cpp
+++ b/tests/stubs/scheduler/pipeline/job.cpp
@@ -75,4 +75,14 @@ const std::string& Job::GetCompilationFlags() const
 {
 	return cflags_;
 }
+
+void Job::SetPreCompilationCommands(std::vector<std::string> value)
+{
+	// noop
+}
+
+const std::vector<std::string>& Job::GetPreCompilationCommands() const
+{
+	return pre_commands_;
+}
 } // namespace scheduler::pipeline

--- a/tests/sys/nix/command/include/fakes/sys/nix/command.hpp
+++ b/tests/sys/nix/command/include/fakes/sys/nix/command.hpp
@@ -43,7 +43,6 @@ public:
 	{}
 
 public:
-	using ::sys::nix::Command::parameters_;
-	using ::sys::nix::Command::program_;
+	using ::sys::nix::Command::command_;
 };
 } // namespace fakes::sys::nix

--- a/tests/sys/nix/command/src/main.cpp
+++ b/tests/sys/nix/command/src/main.cpp
@@ -31,8 +31,7 @@ TEST(CommandTest, TestConstructor)
 	const std::string parameters{"program"};
 	const fakes::sys::nix::Command command{program, parameters};
 
-	EXPECT_EQ(command.program_, program);
-	EXPECT_EQ(command.parameters_, parameters);
+	EXPECT_EQ(command.command_, program + " " + parameters);
 }
 
 /**


### PR DESCRIPTION
This pull request changes the way Lexer and Parser handle separators (like spaces) by categorizing it and adding as parts of strings and arrays. 

Also, thankfully to that, new keywords that are used to specify pre- and -post compilation commands to be run are implemented.