### PR TITLE
Throw an exception when there are no files in the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(${PROJECT_NAME}
     src/parser/parser.cpp
     src/scheduler/exceptions/compilationerrorexception.cpp
     src/scheduler/exceptions/linkerrorexception.cpp
+    src/scheduler/exceptions/nofilesspecifiedexception.cpp
     src/scheduler/exceptions/postcompilationcommandexception.cpp
     src/scheduler/exceptions/precompilationcommandexception.cpp
     src/scheduler/pipeline/job.cpp

--- a/include/scheduler/exceptions/nofilesspecifiedexception.hpp
+++ b/include/scheduler/exceptions/nofilesspecifiedexception.hpp
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace scheduler::exceptions
+{
+/**
+ * @brief An exception, used to notify that the project doesn't have any associated files
+ * 
+ */
+class NoFilesSpecifiedException : public std::runtime_error
+{
+public:
+	/**
+	 * @brief Construct a new NoFilesSpecifiedException object
+	 * 
+	 */
+	explicit NoFilesSpecifiedException();
+};
+} // namespace scheduler::exceptions

--- a/src/scheduler/exceptions/nofilesspecifiedexception.cpp
+++ b/src/scheduler/exceptions/nofilesspecifiedexception.cpp
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "scheduler/exceptions/nofilesspecifiedexception.hpp"
+
+namespace scheduler::exceptions
+{
+NoFilesSpecifiedException::NoFilesSpecifiedException()
+	: std::runtime_error("Files to build the project were not specified.")
+{}
+} // namespace scheduler::exceptions

--- a/src/scheduler/pipeline/pipeline.cpp
+++ b/src/scheduler/pipeline/pipeline.cpp
@@ -29,6 +29,7 @@
 
 #include "scheduler/exceptions/compilationerrorexception.hpp"
 #include "scheduler/exceptions/linkerrorexception.hpp"
+#include "scheduler/exceptions/nofilesspecifiedexception.hpp"
 #include "scheduler/exceptions/postcompilationcommandexception.hpp"
 #include "scheduler/exceptions/precompilationcommandexception.hpp"
 
@@ -59,8 +60,15 @@ void Pipeline::Run() const
 		}
 	}
 
+	// Check if the project contains files
+	const auto& files = job_.GetFiles();
+	if(files.empty())
+	{
+		throw exceptions::NoFilesSpecifiedException();
+	}
+
 	std::stringstream parameters{};
-	for(const auto& file : job_.GetFiles())
+	for(const auto& file : files)
 	{
 		const auto obj = folder / file.filename().replace_extension(".o");
 

--- a/tests/scheduler/exceptions/CMakeLists.txt
+++ b/tests/scheduler/exceptions/CMakeLists.txt
@@ -19,5 +19,6 @@
 
 add_subdirectory(compilationerrorexception)
 add_subdirectory(linkerrorexception)
+add_subdirectory(nofilesspecifiedexception)
 add_subdirectory(postcompilationcommandexception)
 add_subdirectory(precompilationcommandexception)

--- a/tests/scheduler/exceptions/nofilesspecifiedexception/CMakeLists.txt
+++ b/tests/scheduler/exceptions/nofilesspecifiedexception/CMakeLists.txt
@@ -1,0 +1,32 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+project("nofilesspecifiedexception")
+
+set(SOURCES 
+    ${CMAKE_SOURCE_DIR}/src/scheduler/exceptions/nofilesspecifiedexception.cpp
+)
+
+add_executable(${PROJECT_NAME} 
+    ${SOURCES}
+
+    src/main.cpp
+)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/scheduler/exceptions/nofilesspecifiedexception/src/main.cpp
+++ b/tests/scheduler/exceptions/nofilesspecifiedexception/src/main.cpp
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "scheduler/exceptions/nofilesspecifiedexception.hpp"
+
+/**
+ * @brief Check if the exception is constructed with the correct message
+ * 
+ */
+TEST(NoFilesSpecifiedExceptionTest, TestConstructor)
+{
+	const scheduler::exceptions::NoFilesSpecifiedException exception{};
+	EXPECT_STREQ(exception.what(), "Files to build the project were not specified.");
+}

--- a/tests/scheduler/pipeline/pipeline/CMakeLists.txt
+++ b/tests/scheduler/pipeline/pipeline/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
 set(STUBS
     ${STUBS_FOLDER}/scheduler/exceptions/compilationerrorexception.cpp
     ${STUBS_FOLDER}/scheduler/exceptions/linkerrorexception.cpp
+    ${STUBS_FOLDER}/scheduler/exceptions/nofilesspecifiedexception.cpp
     ${STUBS_FOLDER}/scheduler/exceptions/postcompilationcommandexception.cpp
     ${STUBS_FOLDER}/scheduler/exceptions/precompilationcommandexception.cpp
 

--- a/tests/scheduler/pipeline/pipeline/src/stubs/sys/nix/command.cpp
+++ b/tests/scheduler/pipeline/pipeline/src/stubs/sys/nix/command.cpp
@@ -19,7 +19,9 @@
 
 #include "sys/nix/command.hpp"
 
-bool result = true;
+#include <stack>
+
+std::stack<bool> result{};
 
 namespace sys::nix
 {
@@ -35,6 +37,13 @@ Command::Command(std::string program, std::string parameters)
 
 bool Command::Execute()
 {
-	return result;
+	if(result.empty())
+	{
+		return true;
+	}
+
+	const auto data = result.top();
+	result.pop();
+	return data;
 }
 } // namespace sys::nix

--- a/tests/stubs/scheduler/exceptions/nofilesspecifiedexception.cpp
+++ b/tests/stubs/scheduler/exceptions/nofilesspecifiedexception.cpp
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "scheduler/exceptions/nofilesspecifiedexception.hpp"
+
+namespace scheduler::exceptions
+{
+NoFilesSpecifiedException::NoFilesSpecifiedException()
+	: std::runtime_error("")
+{}
+} // namespace scheduler::exceptions


### PR DESCRIPTION
This pul request contains changes, that make the Pipeline class throw an exception, when the user doesn't specify any file to build the project.