### PR TITLE
Add skipping compilation feature for already compiled files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(${PROJECT_NAME}
     src/scheduler/pipeline/job.cpp
     src/scheduler/pipeline/pipeline.cpp
     src/scheduler/executor.cpp
+    src/sys/exceptions/unsupportedcompilerexception.cpp
     src/sys/nix/command.cpp
     src/utils/bufferedlogger.cpp
     src/utils/logger.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(${PROJECT_NAME}
     src/parser/states/keywords/cflags.cpp
     src/parser/states/keywords/deps.cpp
     src/parser/states/keywords/files.cpp
+    src/parser/states/keywords/inc.cpp
     src/parser/states/keywords/let.cpp
     src/parser/states/keywords/post.cpp
     src/parser/states/keywords/pre.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,6 @@ add_executable(${PROJECT_NAME}
     src/parser/tokens/word.cpp
     src/parser/mediator.cpp
     src/parser/parser.cpp
-    src/scheduler/exceptions/compilationerrorexception.cpp
     src/scheduler/exceptions/linkerrorexception.cpp
     src/scheduler/exceptions/nofilesspecifiedexception.cpp
     src/scheduler/exceptions/postcompilationcommandexception.cpp
@@ -75,8 +74,11 @@ add_executable(${PROJECT_NAME}
     src/scheduler/pipeline/job.cpp
     src/scheduler/pipeline/pipeline.cpp
     src/scheduler/executor.cpp
+    src/sys/exceptions/compilationerrorexception.cpp
     src/sys/exceptions/unsupportedcompilerexception.cpp
     src/sys/nix/command.cpp
+    src/sys/tools/compilers/gnuplusplus.cpp
+    src/sys/tools/compilerfactory.cpp
     src/utils/bufferedlogger.cpp
     src/utils/logger.cpp
     src/application.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 add_executable(${PROJECT_NAME} 
+    src/exceptions/filenotfoundexception.cpp
     src/lexer/exceptions/fileemptyexception.cpp
-    src/lexer/exceptions/filenotfoundexception.cpp
     src/lexer/exceptions/unexpectedlexemeexception.cpp
     src/lexer/handlers/handler.cpp
     src/lexer/handlers/operatorhandler.cpp

--- a/include/exceptions/filenotfoundexception.hpp
+++ b/include/exceptions/filenotfoundexception.hpp
@@ -17,13 +17,33 @@
  * under the License.
  */
 
-#include "lexer/exceptions/filenotfoundexception.hpp"
+#pragma once
 
-namespace lexer::exceptions
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+namespace exceptions
 {
-const std::string FileNotFoundException::kMessage{"The given file was not found: "};
+/**
+ * @brief An exception, used to notify that the given file is not found
+ * 
+ */
+class FileNotFoundException : public std::runtime_error
+{
+public:
+	/**
+	 * @brief Construct a new FileNotFoundException object
+	 * 
+	 * @param path - the path to the file
+	 */
+	explicit FileNotFoundException(const std::filesystem::path& path);
 
-FileNotFoundException::FileNotFoundException(const std::filesystem::path& path)
-	: std::runtime_error(kMessage + path.string())
-{}
-} // namespace lexer::exceptions
+protected:
+	/**
+	 * @brief The message, seeing on the exception occurence
+	 * 
+	 */
+	static const std::string kMessage;
+};
+} // namespace exceptions

--- a/include/parser/states/keywords/inc.hpp
+++ b/include/parser/states/keywords/inc.hpp
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "parser/states/types/array.hpp"
+
+namespace parser::states::keywords
+{
+/**
+ * @brief A "Include" state of the parser, used to parse !inc keyword
+ * 
+ */
+class Inc : public types::Array
+{
+public:
+	/**
+     * @brief Construct a new Inc object
+     * 
+     * @param mediator - the associated parser's mediator
+     */
+	explicit Inc(Mediator& mediator);
+
+public:
+	/**
+     * @brief Process the input from the lexer
+     * 
+     * @param lexer - the lexer which handles tokenization of the input file
+     */
+	void Process(lexer::Lexer& lexer);
+};
+} // namespace parser::states::keywords

--- a/include/scheduler/pipeline/job.hpp
+++ b/include/scheduler/pipeline/job.hpp
@@ -152,8 +152,21 @@ public:
 	 * 
 	 * @return const std::string& - the value of the flags
 	 */
-
 	const std::vector<std::string>& GetPostCompilationCommands() const;
+
+	/**
+	 * @brief Add a new include directory to the job
+	 * 
+	 * @param value - the directory to include
+	 */
+	void AddIncludeDirectory(std::filesystem::path value);
+
+	/**
+	 * @brief Get the include directories
+	 * 
+	 * @return std::vector<std::filesystem::path>& - the include directories
+	 */
+	const std::vector<std::filesystem::path>& GetIncludeDirectories() const;
 
 protected:
 	/**
@@ -197,5 +210,11 @@ protected:
 	 * 
 	 */
 	std::vector<std::string> post_commands_;
+
+	/**
+	 * @brief The include directories the project has
+	 * 
+	 */
+	std::vector<std::filesystem::path> include_directories_;
 };
 } // namespace scheduler::pipeline

--- a/include/scheduler/pipeline/pipeline.hpp
+++ b/include/scheduler/pipeline/pipeline.hpp
@@ -70,15 +70,6 @@ public:
 
 protected:
 	/**
-	 * @brief Compile the given file
-	 * 
-	 * @param file - the source file to compile
-	 * @param out - the output
-	 */
-	void Compile(const std::filesystem::path& file, const std::filesystem::path& out) const;
-
-protected:
-	/**
 	 * @brief The associated job
 	 * 
 	 */

--- a/include/scheduler/pipeline/pipeline.hpp
+++ b/include/scheduler/pipeline/pipeline.hpp
@@ -80,6 +80,16 @@ protected:
 											   std::vector<std::filesystem::path> files) const;
 
 	/**
+	 * @brief Check if the object file is already compiled
+	 * 
+	 * @param file - the file to check
+	 * @param folder - the output folder of the program
+	 * @return true if the file has the newest object file compiled for it
+	 * @return false otherwise
+	 */
+	bool IsCompiled(const std::filesystem::path& file, const std::filesystem::path& folder) const;
+
+	/**
 	 * @brief Link everything into one executable
 	 * 
 	 * @param folder - the folder where to put the executable

--- a/include/scheduler/pipeline/pipeline.hpp
+++ b/include/scheduler/pipeline/pipeline.hpp
@@ -70,6 +70,37 @@ public:
 
 protected:
 	/**
+	 * @brief Run the compilation for the given files
+	 * 
+	 * @param folder - the folder where to store the output
+	 * @param files - a vector of files
+	 * @return std::vector<std::filesystem::path> - a vector of object files names
+	 */
+	std::vector<std::filesystem::path> Compile(const std::filesystem::path& folder,
+											   std::vector<std::filesystem::path> files) const;
+
+	/**
+	 * @brief Link everything into one executable
+	 * 
+	 * @param folder - the folder where to put the executable
+	 * @param files - the files to use
+	 */
+	void Link(const std::filesystem::path& folder, std::vector<std::filesystem::path> files) const;
+
+	/**
+	 * @brief Execute preprocessing commands
+	 * 
+	 */
+	void ExecutePreprocessingCommands() const;
+
+	/**
+	 * @brief Execute postprocessing commands
+	 * 
+	 */
+	void ExecutePostprocessingCommands() const;
+
+protected:
+	/**
 	 * @brief The associated job
 	 * 
 	 */

--- a/include/scheduler/pipeline/pipeline.hpp
+++ b/include/scheduler/pipeline/pipeline.hpp
@@ -23,6 +23,7 @@
 #include <queue>
 
 #include "scheduler/pipeline/job.hpp"
+#include "sys/tools/compiler.hpp"
 
 namespace scheduler::pipeline
 {
@@ -82,5 +83,11 @@ protected:
 	 * 
 	 */
 	Job job_;
+
+	/**
+	 * @brief The compiler that is used in the pipeline
+	 * 
+	 */
+	std::unique_ptr<sys::tools::Compiler> compiler_;
 };
 } // namespace scheduler::pipeline

--- a/include/sys/command.hpp
+++ b/include/sys/command.hpp
@@ -34,5 +34,12 @@ public:
      * @return true if the command was run successfully, false otherwise
      */
 	virtual bool Execute() = 0;
+
+	/**
+      * @brief Get the output of the command
+      * 
+      * @return std::string - the output from the command
+      */
+	virtual std::string GetOutput() const = 0;
 };
 } // namespace sys

--- a/include/sys/exceptions/compilationerrorexception.hpp
+++ b/include/sys/exceptions/compilationerrorexception.hpp
@@ -17,21 +17,33 @@
  * under the License.
  */
 
-#include <gtest/gtest.h>
+#pragma once
 
-#include "fakes/scheduler/exceptions/compilationerrorexception.hpp"
+#include <filesystem>
+#include <stdexcept>
+#include <string>
 
+namespace sys::exceptions
+{
 /**
- * @brief Check if the exception is constructed with the correct message
+ * @brief An exception, used to notify that the compilation proces for the given file has failed
  * 
  */
-TEST(CompilationErrorExceptionTest, TestConstructor)
+class CompilationErrorException : public std::runtime_error
 {
-	namespace exc = fakes::scheduler::exceptions;
-	namespace fs = std::filesystem;
+public:
+	/**
+	 * @brief Construct a new CompilationErrorException object
+	 * 
+	 * @param file - the file that caused the error
+	 */
+	explicit CompilationErrorException(const std::filesystem::path& file);
 
-	const fs::path path{"path"};
-	const exc::CompilationErrorException exception{path};
-	const auto data = exc::CompilationErrorException::kMessage + path.string();
-	EXPECT_STREQ(exception.what(), data.c_str());
-}
+protected:
+	/**
+	 * @brief The message, seeing on the exception occurence
+	 * 
+	 */
+	static const std::string kMessage;
+};
+} // namespace sys::exceptions

--- a/include/sys/exceptions/unsupportedcompilerexception.hpp
+++ b/include/sys/exceptions/unsupportedcompilerexception.hpp
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace sys::exceptions
+{
+/**
+ * @brief An exception, used to notify that the specified compiler is not supported
+ * 
+ */
+class UnsupportedCompilerException : public std::runtime_error
+{
+public:
+	/**
+	 * @brief Construct a new UnsupportedCompilerException object
+	 * 
+	 * @param compiler - the compiler that has no support
+	 */
+	explicit UnsupportedCompilerException(std::string compiler);
+
+protected:
+	/**
+	 * @brief The message, seeing on the exception occurence
+	 * 
+	 */
+	static const std::string kMessage;
+};
+} // namespace sys::exceptions

--- a/include/sys/nix/command.hpp
+++ b/include/sys/nix/command.hpp
@@ -55,11 +55,24 @@ public:
      */
 	bool Execute() override;
 
+	/**
+      * @brief Get the output of the command
+      * 
+      * @return std::string - the output from the command
+      */
+	std::string GetOutput() const override;
+
 protected:
 	/**
      * @brief The command
      * 
      */
 	const std::string command_;
+
+	/**
+      * @brief Command's output
+      * 
+      */
+	std::string output_;
 };
 } // namespace sys::nix

--- a/include/sys/tools/compiler.hpp
+++ b/include/sys/tools/compiler.hpp
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace sys::tools
+{
+/**
+ * @brief An interface for the compilers that are supported by the application
+ * 
+ */
+struct Compiler
+{
+	/**
+	 * @brief Compile the given file
+	 * 
+	 * @param file - the file to compile
+	 * @param out - the file where to store the output
+	 */
+	virtual void Compile(const std::filesystem::path& file, const std::filesystem::path& out) = 0;
+};
+} // namespace sys::tools

--- a/include/sys/tools/compiler.hpp
+++ b/include/sys/tools/compiler.hpp
@@ -38,5 +38,14 @@ struct Compiler
 	 * @param out - the file where to store the output
 	 */
 	virtual void Compile(const std::filesystem::path& file, const std::filesystem::path& out) = 0;
+
+	/**
+	 * @brief Get the dependencies of the file
+	 * 
+	 * @param file - the file to inspect
+	 * @return std::vector<std::filesystem::path> - a vector of dependencies
+	 */
+	virtual std::vector<std::filesystem::path>
+	GetDependencies(const std::filesystem::path& file) const = 0;
 };
 } // namespace sys::tools

--- a/include/sys/tools/compilerfactory.hpp
+++ b/include/sys/tools/compilerfactory.hpp
@@ -37,8 +37,11 @@ public:
      * 
      * @param value - the compiler to create
      * @param flags - compiler flags
+     * @param include_directories - the directories to include while building the application
      * @return std::unique_ptr<Compiler> - a pointer to the compiler instance
      */
-	static std::unique_ptr<Compiler> Create(const std::string& value, std::string flags);
+	static std::unique_ptr<Compiler> Create(const std::string& value,
+											std::string flags,
+											std::vector<std::filesystem::path> include_directories);
 };
 } // namespace sys::tools

--- a/include/sys/tools/compilerfactory.hpp
+++ b/include/sys/tools/compilerfactory.hpp
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * 
  *  http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,13 +17,28 @@
  * under the License.
  */
 
-#include "scheduler/exceptions/compilationerrorexception.hpp"
+#pragma once
 
-namespace scheduler::exceptions
+#include <memory>
+
+#include "sys/tools/compiler.hpp"
+
+namespace sys::tools
 {
-const std::string CompilationErrorException::kMessage{};
-
-CompilationErrorException::CompilationErrorException(const std::filesystem::path& file)
-	: std::runtime_error("")
-{}
-} // namespace scheduler::exceptions
+/**
+ * @brief A class with the factory method for compiler instance creation
+ * 
+ */
+class CompilerFactory
+{
+public:
+	/**
+     * @brief Create the given compiler
+     * 
+     * @param value - the compiler to create
+     * @param flags - compiler flags
+     * @return std::unique_ptr<Compiler> - a pointer to the compiler instance
+     */
+	static std::unique_ptr<Compiler> Create(const std::string& value, std::string flags);
+};
+} // namespace sys::tools

--- a/include/sys/tools/compilers/gnuplusplus.hpp
+++ b/include/sys/tools/compilers/gnuplusplus.hpp
@@ -19,6 +19,9 @@
 
 #pragma once
 
+#include <filesystem>
+#include <vector>
+
 #include "sys/tools/compiler.hpp"
 
 namespace sys::tools::compilers
@@ -34,8 +37,10 @@ public:
 	 * @brief Construct a new GNUPlusPlus object
 	 * 
 	 * @param flags - compiler flags
+	 * @param include_directories - the directories to include while building the application
 	 */
-	explicit GNUPlusPlus(std::string&& flags);
+	explicit GNUPlusPlus(std::string&& flags,
+						 std::vector<std::filesystem::path>&& include_directories);
 
 public:
 	/**
@@ -59,5 +64,11 @@ protected:
 	 * 
 	 */
 	const std::string kFlags;
+
+	/**
+	 * @brief The directories to include while building the application
+	 * 
+	 */
+	const std::vector<std::filesystem::path> kDirectories;
 };
 } // namespace sys::tools::compilers

--- a/include/sys/tools/compilers/gnuplusplus.hpp
+++ b/include/sys/tools/compilers/gnuplusplus.hpp
@@ -51,12 +51,31 @@ public:
 	 */
 	void Compile(const std::filesystem::path& file, const std::filesystem::path& out) override;
 
+	/**
+	 * @brief Get the dependencies of the file
+	 * 
+	 * @param file - the file to inspect
+	 * @return std::vector<std::filesystem::path> - a vector of dependencies
+	 */
+	std::vector<std::filesystem::path>
+	GetDependencies(const std::filesystem::path& file) const override;
+
 public:
 	/**
 	 * @brief The compiler program name
 	 * 
 	 */
 	static const std::string kCompiler;
+
+protected:
+	/**
+	 * @brief Split the given string
+	 * 
+	 * @param string - the string to split
+	 * @param delimiter - the delimiter to use to split the string
+	 * @return std::vector<std::string> - a split string
+	 */
+	static std::vector<std::string> Split(std::string string, const std::string& delimiter);
 
 protected:
 	/**

--- a/include/sys/tools/compilers/gnuplusplus.hpp
+++ b/include/sys/tools/compilers/gnuplusplus.hpp
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * 
  *  http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,29 +19,45 @@
 
 #pragma once
 
-#include "scheduler/exceptions/compilationerrorexception.hpp"
+#include "sys/tools/compiler.hpp"
 
-namespace fakes::scheduler::exceptions
+namespace sys::tools::compilers
 {
-namespace exc = ::scheduler::exceptions;
-
 /**
- * @brief An fake for the exception, used to notify that the compilation proces for the given file has failed
+ * @brief An interface for the compilers that are supported by the application
  * 
  */
-class CompilationErrorException : public exc::CompilationErrorException
+class GNUPlusPlus : public Compiler
 {
 public:
 	/**
-	 * @brief Construct a new CompilationErrorException object
+	 * @brief Construct a new GNUPlusPlus object
 	 * 
-	 * @param file - the file that caused the error
+	 * @param flags - compiler flags
 	 */
-	explicit CompilationErrorException(const std::filesystem::path& file)
-		: exc::CompilationErrorException{file}
-	{}
+	explicit GNUPlusPlus(std::string&& flags);
 
 public:
-	using exc::CompilationErrorException::kMessage;
+	/**
+	 * @brief Compile the given file
+	 * 
+	 * @param file - the file to compile
+	 * @param out - the file where to store the output
+	 */
+	void Compile(const std::filesystem::path& file, const std::filesystem::path& out) override;
+
+public:
+	/**
+	 * @brief The compiler program name
+	 * 
+	 */
+	static const std::string kCompiler;
+
+protected:
+	/**
+	 * @brief The flags used during the compilation process
+	 * 
+	 */
+	const std::string kFlags;
 };
-} // namespace fakes::scheduler::exceptions
+} // namespace sys::tools::compilers

--- a/src/exceptions/filenotfoundexception.cpp
+++ b/src/exceptions/filenotfoundexception.cpp
@@ -17,33 +17,13 @@
  * under the License.
  */
 
-#pragma once
+#include "exceptions/filenotfoundexception.hpp"
 
-#include <filesystem>
-#include <stdexcept>
-#include <string>
-
-namespace lexer::exceptions
+namespace exceptions
 {
-/**
- * @brief An exception, used to notify that the given file is not found
- * 
- */
-class FileNotFoundException : public std::runtime_error
-{
-public:
-	/**
-	 * @brief Construct a new FileNotFoundException object
-	 * 
-	 * @param path - the path to the file
-	 */
-	explicit FileNotFoundException(const std::filesystem::path& path);
+const std::string FileNotFoundException::kMessage{"The given file was not found: "};
 
-protected:
-	/**
-	 * @brief The message, seeing on the exception occurence
-	 * 
-	 */
-	static const std::string kMessage;
-};
-} // namespace lexer::exceptions
+FileNotFoundException::FileNotFoundException(const std::filesystem::path& path)
+	: std::runtime_error(kMessage + path.string())
+{}
+} // namespace exceptions

--- a/src/lexer/scanner.cpp
+++ b/src/lexer/scanner.cpp
@@ -21,8 +21,8 @@
 
 #include <cctype>
 
+#include "exceptions/filenotfoundexception.hpp"
 #include "lexer/exceptions/fileemptyexception.hpp"
-#include "lexer/exceptions/filenotfoundexception.hpp"
 
 namespace lexer
 {
@@ -39,7 +39,7 @@ Scanner::Scanner(const std::filesystem::path& path)
 	// If the file doesn't exist or it is not a regular file, throw an exception
 	if(!fs::exists(path) || !fs::is_regular_file(path))
 	{
-		throw exceptions::FileNotFoundException(path);
+		throw ::exceptions::FileNotFoundException(path);
 	}
 
 	// Throw an exception if the file is empty
@@ -51,7 +51,7 @@ Scanner::Scanner(const std::filesystem::path& path)
 	file_.open(path);
 	if(!file_.is_open())
 	{
-		throw exceptions::FileNotFoundException(path);
+		throw ::exceptions::FileNotFoundException(path);
 	}
 
 	// Get the first line from file and initialize the iterator

--- a/src/parser/states/keyword.cpp
+++ b/src/parser/states/keyword.cpp
@@ -24,6 +24,7 @@
 #include "parser/states/keywords/cflags.hpp"
 #include "parser/states/keywords/deps.hpp"
 #include "parser/states/keywords/files.hpp"
+#include "parser/states/keywords/inc.hpp"
 #include "parser/states/keywords/let.hpp"
 #include "parser/states/keywords/post.hpp"
 #include "parser/states/keywords/pre.hpp"
@@ -79,6 +80,11 @@ void Keyword::Process(lexer::Lexer& lexer)
 	else if(keyword == "let")
 	{
 		mediator_.SetState(std::make_unique<keywords::Let>(mediator_));
+		return;
+	}
+	else if(keyword == "inc")
+	{
+		mediator_.SetState(std::make_unique<keywords::Inc>(mediator_));
 		return;
 	}
 

--- a/src/parser/states/keywords/inc.cpp
+++ b/src/parser/states/keywords/inc.cpp
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "parser/states/keywords/inc.hpp"
+
+#include "parser/states/statement.hpp"
+
+namespace parser::states::keywords
+{
+Inc::Inc(Mediator& mediator)
+	: Array{mediator}
+{}
+
+void Inc::Process(lexer::Lexer& lexer)
+{
+	Array::Process(lexer);
+
+	// Set the job's Inc
+	auto& job = mediator_.BorrowJob();
+	for(auto& name : Array::GetValue())
+	{
+		job.AddIncludeDirectory(std::filesystem::path{name});
+	}
+
+	// Return to the Statement state
+	mediator_.SetState(std::make_unique<Statement>(mediator_));
+}
+} // namespace parser::states::keywords

--- a/src/scheduler/pipeline/job.cpp
+++ b/src/scheduler/pipeline/job.cpp
@@ -90,4 +90,13 @@ const std::vector<std::string>& Job::GetPostCompilationCommands() const
 	return post_commands_;
 }
 
+void Job::AddIncludeDirectory(std::filesystem::path value)
+{
+	include_directories_.push_back(std::move(value));
+}
+
+const std::vector<std::filesystem::path>& Job::GetIncludeDirectories() const
+{
+	return include_directories_;
+}
 } // namespace scheduler::pipeline

--- a/src/scheduler/pipeline/pipeline.cpp
+++ b/src/scheduler/pipeline/pipeline.cpp
@@ -27,6 +27,7 @@
 #endif
 // clang-format on
 
+#include "exceptions/filenotfoundexception.hpp"
 #include "scheduler/exceptions/compilationerrorexception.hpp"
 #include "scheduler/exceptions/linkerrorexception.hpp"
 #include "scheduler/exceptions/nofilesspecifiedexception.hpp"
@@ -70,6 +71,12 @@ void Pipeline::Run() const
 	std::stringstream parameters{};
 	for(const auto& file : files)
 	{
+		// Check if the specified file exists
+		if(!std::filesystem::exists(file))
+		{
+			throw ::exceptions::FileNotFoundException(file);
+		}
+
 		const auto obj = folder / file.filename().replace_extension(".o");
 
 		// Add the object file name to the list of parameters

--- a/src/scheduler/pipeline/pipeline.cpp
+++ b/src/scheduler/pipeline/pipeline.cpp
@@ -80,9 +80,8 @@ void Pipeline::Run() const
 			throw ::exceptions::FileNotFoundException(file);
 		}
 
-		const auto obj = folder / file.filename().replace_extension(".o");
-
 		// Add the object file name to the list of parameters
+		const auto obj = folder / file.filename().replace_extension(".o");
 		parameters << std::move(obj.string()) << " ";
 
 		compiler_->Compile(job_.GetProjectPath() / file, obj);

--- a/src/scheduler/pipeline/pipeline.cpp
+++ b/src/scheduler/pipeline/pipeline.cpp
@@ -43,8 +43,9 @@ Pipeline::Pipeline(Job job)
 	using namespace sys::tools;
 	using namespace sys::tools::compilers;
 
-	compiler_ =
-		std::move(CompilerFactory::Create(GNUPlusPlus::kCompiler, job_.GetCompilationFlags()));
+	compiler_ = std::move(CompilerFactory::Create(GNUPlusPlus::kCompiler,
+												  job_.GetCompilationFlags(),
+												  std::move(job_.GetIncludeDirectories())));
 }
 
 void Pipeline::Run() const

--- a/src/sys/exceptions/compilationerrorexception.cpp
+++ b/src/sys/exceptions/compilationerrorexception.cpp
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/exceptions/compilationerrorexception.hpp"
+
+namespace sys::exceptions
+{
+const std::string CompilationErrorException::kMessage{"Compilation failed for the file: "};
+
+CompilationErrorException::CompilationErrorException(const std::filesystem::path& file)
+	: std::runtime_error(kMessage + file.string())
+{}
+} // namespace sys::exceptions

--- a/src/sys/exceptions/unsupportedcompilerexception.cpp
+++ b/src/sys/exceptions/unsupportedcompilerexception.cpp
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/exceptions/unsupportedcompilerexception.hpp"
+
+namespace sys::exceptions
+{
+const std::string UnsupportedCompilerException::kMessage{
+	"The following compiler is not supported: "};
+
+UnsupportedCompilerException::UnsupportedCompilerException(std::string project)
+	: std::runtime_error(kMessage + project)
+{}
+} // namespace sys::exceptions

--- a/src/sys/nix/command.cpp
+++ b/src/sys/nix/command.cpp
@@ -19,8 +19,9 @@
 
 #include "sys/nix/command.hpp"
 
+#include <array>
+#include <cstdio>
 #include <cstdlib>
-#include <sstream>
 
 namespace sys::nix
 {
@@ -34,6 +35,23 @@ Command::Command(std::string program, std::string parameters)
 
 bool Command::Execute()
 {
-	return std::system(command_.c_str()) == 0;
+	auto pipe = popen(command_.c_str(), "r");
+	if(!pipe)
+	{
+		return false;
+	}
+
+	std::array<char, 128> buffer;
+	while(fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr)
+	{
+		output_ += buffer.data();
+	}
+
+	return pclose(pipe) == 0;
+}
+
+std::string Command::GetOutput() const
+{
+	return output_;
 }
 } // namespace sys::nix

--- a/src/sys/tools/compilerfactory.cpp
+++ b/src/sys/tools/compilerfactory.cpp
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/tools/compilerfactory.hpp"
+
+#include "sys/exceptions/unsupportedcompilerexception.hpp"
+#include "sys/tools/compilers/gnuplusplus.hpp"
+
+namespace sys::tools
+{
+std::unique_ptr<Compiler> CompilerFactory::Create(const std::string& value, std::string flags)
+{
+	if(value == compilers::GNUPlusPlus::kCompiler)
+	{
+		return std::unique_ptr<Compiler>{new compilers::GNUPlusPlus(std::move(flags))};
+	}
+
+	throw exceptions::UnsupportedCompilerException{value};
+}
+} // namespace sys::tools

--- a/src/sys/tools/compilerfactory.cpp
+++ b/src/sys/tools/compilerfactory.cpp
@@ -24,11 +24,15 @@
 
 namespace sys::tools
 {
-std::unique_ptr<Compiler> CompilerFactory::Create(const std::string& value, std::string flags)
+std::unique_ptr<Compiler>
+CompilerFactory::Create(const std::string& value,
+						std::string flags,
+						std::vector<std::filesystem::path> include_directories)
 {
 	if(value == compilers::GNUPlusPlus::kCompiler)
 	{
-		return std::unique_ptr<Compiler>{new compilers::GNUPlusPlus(std::move(flags))};
+		return std::unique_ptr<Compiler>{
+			new compilers::GNUPlusPlus(std::move(flags), std::move(include_directories))};
 	}
 
 	throw exceptions::UnsupportedCompilerException{value};

--- a/src/sys/tools/compilers/gnuplusplus.cpp
+++ b/src/sys/tools/compilers/gnuplusplus.cpp
@@ -40,14 +40,22 @@ namespace sys::tools::compilers
 {
 const std::string GNUPlusPlus::kCompiler{"g++"};
 
-GNUPlusPlus::GNUPlusPlus(std::string&& flags)
+GNUPlusPlus::GNUPlusPlus(std::string&& flags,
+						 std::vector<std::filesystem::path>&& include_directories)
 	: kFlags{std::move(flags)}
+	, kDirectories{std::move(include_directories)}
 {}
 
 void GNUPlusPlus::Compile(const std::filesystem::path& file, const std::filesystem::path& out)
 {
 	std::stringstream parameters;
 	parameters << kFlags << " -c " << file.string() << " -o " << out.string();
+
+	// Add include directories
+	for(auto& directory : kDirectories)
+	{
+		parameters << " -I " << directory.string();
+	}
 
 	SystemCommand command{kCompiler, parameters.str()};
 	if(!command.Execute())

--- a/src/sys/tools/compilers/gnuplusplus.cpp
+++ b/src/sys/tools/compilers/gnuplusplus.cpp
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/tools/compilers/gnuplusplus.hpp"
+
+// clang-format off
+#ifdef __linux__
+    #include "sys/nix/command.hpp"
+
+    using SystemCommand = sys::nix::Command;
+#endif
+// clang-format on
+
+#include <sstream>
+
+#include "sys/exceptions/compilationerrorexception.hpp"
+
+namespace
+{
+const std::string kCompiler = "g++";
+}
+
+namespace sys::tools::compilers
+{
+const std::string GNUPlusPlus::kCompiler{"g++"};
+
+GNUPlusPlus::GNUPlusPlus(std::string&& flags)
+	: kFlags{std::move(flags)}
+{}
+
+void GNUPlusPlus::Compile(const std::filesystem::path& file, const std::filesystem::path& out)
+{
+	std::stringstream parameters;
+	parameters << kFlags << " -c " << file.string() << " -o " << out.string();
+
+	SystemCommand command{kCompiler, parameters.str()};
+	if(!command.Execute())
+	{
+		throw exceptions::CompilationErrorException(file);
+	}
+}
+} // namespace sys::tools::compilers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ link_libraries(
 )
 
 add_subdirectory(application)
+add_subdirectory(exceptions)
 add_subdirectory(lexer)
 add_subdirectory(parser)
 add_subdirectory(scheduler)

--- a/tests/application/src/stubs/scheduler/pipeline/pipeline.cpp
+++ b/tests/application/src/stubs/scheduler/pipeline/pipeline.cpp
@@ -36,9 +36,4 @@ void Pipeline::Run() const
 		throw exceptions::LinkErrorException("");
 	}
 }
-
-void Pipeline::Compile(const std::filesystem::path& file, const std::filesystem::path& out) const
-{
-	// noop
-}
 } // namespace scheduler::pipeline

--- a/tests/exceptions/CMakeLists.txt
+++ b/tests/exceptions/CMakeLists.txt
@@ -17,20 +17,4 @@
 # under the License.
 #
 
-project("filenotfoundexception")
-
-set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/lexer/exceptions/filenotfoundexception.cpp
-)
-
-add_executable(${PROJECT_NAME} 
-    ${SOURCES}
-
-    src/main.cpp
-)
-
-target_include_directories(${PROJECT_NAME} PUBLIC
-    include
-)
-
-add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})
+add_subdirectory(filenotfoundexception)

--- a/tests/exceptions/filenotfoundexception/CMakeLists.txt
+++ b/tests/exceptions/filenotfoundexception/CMakeLists.txt
@@ -17,36 +17,20 @@
 # under the License.
 #
 
-project("wordhandler")
+project("filenotfoundexception")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/lexer/handlers/wordhandler.cpp
-)
-
-set(STUBS
-    ${STUBS_FOLDER}/exceptions/filenotfoundexception.cpp
-    ${STUBS_FOLDER}/lexer/exceptions/fileemptyexception.cpp
-    
-    src/stubs/lexer/handlers/handler.cpp
-    src/stubs/lexer/context.cpp
-    src/stubs/lexer/scanner.cpp
-    src/stubs/parser/tokens/word.cpp
+    ${CMAKE_SOURCE_DIR}/src/exceptions/filenotfoundexception.cpp
 )
 
 add_executable(${PROJECT_NAME} 
     ${SOURCES}
-    ${STUBS}
 
     src/main.cpp
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     include
-)
-
-target_link_libraries(${PROJECT_NAME} 
-    gmock
-    gmock_main
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/exceptions/filenotfoundexception/include/fakes/exceptions/filenotfoundexception.hpp
+++ b/tests/exceptions/filenotfoundexception/include/fakes/exceptions/filenotfoundexception.hpp
@@ -19,11 +19,11 @@
 
 #pragma once
 
-#include "lexer/exceptions/filenotfoundexception.hpp"
+#include "exceptions/filenotfoundexception.hpp"
 
-namespace fakes::lexer::exceptions
+namespace fakes::exceptions
 {
-namespace exc = ::lexer::exceptions;
+namespace exc = ::exceptions;
 
 /**
  * @brief An fake for the exception, used to notify that the given lexeme is unexpected
@@ -44,4 +44,4 @@ public:
 public:
 	using exc::FileNotFoundException::kMessage;
 };
-} // namespace fakes::lexer::exceptions
+} // namespace fakes::exceptions

--- a/tests/exceptions/filenotfoundexception/src/main.cpp
+++ b/tests/exceptions/filenotfoundexception/src/main.cpp
@@ -19,7 +19,7 @@
 
 #include <gtest/gtest.h>
 
-#include "fakes/lexer/exceptions/filenotfoundexception.hpp"
+#include "fakes/exceptions/filenotfoundexception.hpp"
 
 /**
  * @brief Check if the exception is constructed with the correct message
@@ -27,7 +27,7 @@
  */
 TEST(FileNotFoundExceptionTest, TestConstructor)
 {
-	namespace exc = fakes::lexer::exceptions;
+	namespace exc = fakes::exceptions;
 	namespace fs = std::filesystem;
 
 	const fs::path path{"path"};

--- a/tests/lexer/exceptions/CMakeLists.txt
+++ b/tests/lexer/exceptions/CMakeLists.txt
@@ -18,5 +18,4 @@
 #
 
 add_subdirectory(fileemptyexception)
-add_subdirectory(filenotfoundexception)
 add_subdirectory(unexpectedlexemeexception)

--- a/tests/lexer/handlers/handler/CMakeLists.txt
+++ b/tests/lexer/handlers/handler/CMakeLists.txt
@@ -24,8 +24,8 @@ set(SOURCES
 )
 
 set(STUBS
+    ${STUBS_FOLDER}/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/lexer/exceptions/fileemptyexception.cpp
-    ${STUBS_FOLDER}/lexer/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/lexer/exceptions/unexpectedlexemeexception.cpp
 
     src/stubs/lexer/context.cpp

--- a/tests/lexer/handlers/handler/src/stubs/lexer/scanner.cpp
+++ b/tests/lexer/handlers/handler/src/stubs/lexer/scanner.cpp
@@ -19,7 +19,7 @@
 
 #include "lexer/scanner.hpp"
 
-#include "lexer/exceptions/filenotfoundexception.hpp"
+#include "exceptions/filenotfoundexception.hpp"
 
 namespace lexer
 {
@@ -28,7 +28,7 @@ Scanner::Scanner(const std::filesystem::path& path)
 	file_.open(path);
 	if(!file_.is_open())
 	{
-		throw exceptions::FileNotFoundException(path);
+		throw ::exceptions::FileNotFoundException(path);
 	}
 
 	// Get the first line from file and initialize the iterator

--- a/tests/lexer/handlers/operatorhandler/CMakeLists.txt
+++ b/tests/lexer/handlers/operatorhandler/CMakeLists.txt
@@ -24,8 +24,8 @@ set(SOURCES
 )
 
 set(STUBS
+    ${STUBS_FOLDER}/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/lexer/exceptions/fileemptyexception.cpp
-    ${STUBS_FOLDER}/lexer/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/lexer/exceptions/unexpectedlexemeexception.cpp
     ${STUBS_FOLDER}/lexer/context.cpp
 

--- a/tests/lexer/handlers/operatorhandler/src/stubs/lexer/scanner.cpp
+++ b/tests/lexer/handlers/operatorhandler/src/stubs/lexer/scanner.cpp
@@ -19,7 +19,7 @@
 
 #include "lexer/scanner.hpp"
 
-#include "lexer/exceptions/filenotfoundexception.hpp"
+#include "exceptions/filenotfoundexception.hpp"
 
 namespace lexer
 {
@@ -28,7 +28,7 @@ Scanner::Scanner(const std::filesystem::path& path)
 	file_.open(path);
 	if(!file_.is_open())
 	{
-		throw exceptions::FileNotFoundException(path);
+		throw ::exceptions::FileNotFoundException(path);
 	}
 
 	// Get the first line from file and initialize the iterator

--- a/tests/lexer/handlers/punctuatorhandler/CMakeLists.txt
+++ b/tests/lexer/handlers/punctuatorhandler/CMakeLists.txt
@@ -24,8 +24,8 @@ set(SOURCES
 )
 
 set(STUBS
+    ${STUBS_FOLDER}/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/lexer/exceptions/fileemptyexception.cpp
-    ${STUBS_FOLDER}/lexer/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/lexer/exceptions/unexpectedlexemeexception.cpp
     ${STUBS_FOLDER}/lexer/context.cpp
 

--- a/tests/lexer/handlers/punctuatorhandler/src/stubs/lexer/scanner.cpp
+++ b/tests/lexer/handlers/punctuatorhandler/src/stubs/lexer/scanner.cpp
@@ -19,7 +19,7 @@
 
 #include "lexer/scanner.hpp"
 
-#include "lexer/exceptions/filenotfoundexception.hpp"
+#include "exceptions/filenotfoundexception.hpp"
 
 namespace lexer
 {
@@ -28,7 +28,7 @@ Scanner::Scanner(const std::filesystem::path& path)
 	file_.open(path);
 	if(!file_.is_open())
 	{
-		throw exceptions::FileNotFoundException(path);
+		throw ::exceptions::FileNotFoundException(path);
 	}
 
 	// Get the first line from file and initialize the iterator

--- a/tests/lexer/handlers/separatorhandler/CMakeLists.txt
+++ b/tests/lexer/handlers/separatorhandler/CMakeLists.txt
@@ -24,8 +24,8 @@ set(SOURCES
 )
 
 set(STUBS
+    ${STUBS_FOLDER}/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/lexer/exceptions/fileemptyexception.cpp
-    ${STUBS_FOLDER}/lexer/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/lexer/exceptions/unexpectedlexemeexception.cpp
     ${STUBS_FOLDER}/lexer/context.cpp
 

--- a/tests/lexer/handlers/separatorhandler/src/stubs/lexer/scanner.cpp
+++ b/tests/lexer/handlers/separatorhandler/src/stubs/lexer/scanner.cpp
@@ -19,7 +19,7 @@
 
 #include "lexer/scanner.hpp"
 
-#include "lexer/exceptions/filenotfoundexception.hpp"
+#include "exceptions/filenotfoundexception.hpp"
 
 namespace lexer
 {
@@ -28,7 +28,7 @@ Scanner::Scanner(const std::filesystem::path& path)
 	file_.open(path);
 	if(!file_.is_open())
 	{
-		throw exceptions::FileNotFoundException(path);
+		throw ::exceptions::FileNotFoundException(path);
 	}
 
 	// Get the first line from file and initialize the iterator

--- a/tests/lexer/handlers/wordhandler/src/stubs/lexer/scanner.cpp
+++ b/tests/lexer/handlers/wordhandler/src/stubs/lexer/scanner.cpp
@@ -19,7 +19,7 @@
 
 #include "lexer/scanner.hpp"
 
-#include "lexer/exceptions/filenotfoundexception.hpp"
+#include "exceptions/filenotfoundexception.hpp"
 
 namespace lexer
 {
@@ -28,7 +28,7 @@ Scanner::Scanner(const std::filesystem::path& path)
 	file_.open(path);
 	if(!file_.is_open())
 	{
-		throw exceptions::FileNotFoundException(path);
+		throw ::exceptions::FileNotFoundException(path);
 	}
 
 	// Get the first line from file and initialize the iterator

--- a/tests/lexer/scanner/CMakeLists.txt
+++ b/tests/lexer/scanner/CMakeLists.txt
@@ -21,7 +21,7 @@ project("scanner")
 
 set(SOURCES 
     ${CMAKE_SOURCE_DIR}/src/lexer/exceptions/fileemptyexception.cpp
-    ${CMAKE_SOURCE_DIR}/src/lexer/exceptions/filenotfoundexception.cpp
+    ${CMAKE_SOURCE_DIR}/src/exceptions/filenotfoundexception.cpp
     ${CMAKE_SOURCE_DIR}/src/lexer/scanner.cpp
 )
 

--- a/tests/lexer/scanner/src/main.cpp
+++ b/tests/lexer/scanner/src/main.cpp
@@ -21,9 +21,9 @@
 
 #include <gtest/gtest.h>
 
+#include "exceptions/filenotfoundexception.hpp"
 #include "fakes/lexer/scanner.hpp"
 #include "lexer/exceptions/fileemptyexception.hpp"
-#include "lexer/exceptions/filenotfoundexception.hpp"
 
 namespace original = lexer;
 namespace fake = fakes::lexer;
@@ -86,7 +86,7 @@ const fs::path ScannerTest::kFilePath{"build.bbs"};
 TEST(ScannerTestNoFixture, TestConstructorFileNotFound)
 {
 	const std::string filename{""};
-	EXPECT_THROW(fake::Scanner instance{filename}, original::exceptions::FileNotFoundException);
+	EXPECT_THROW(fake::Scanner instance{filename}, ::exceptions::FileNotFoundException);
 }
 
 /**
@@ -100,7 +100,7 @@ TEST(ScannerTestNoFixture, TestConstructorDirectory)
 	// Create a new directory
 	fs::create_directory(name);
 
-	EXPECT_THROW(fake::Scanner instance{name}, original::exceptions::FileNotFoundException);
+	EXPECT_THROW(fake::Scanner instance{name}, ::exceptions::FileNotFoundException);
 
 	// Remove the directory
 	fs::remove(name);

--- a/tests/parser/states/keyword/src/main.cpp
+++ b/tests/parser/states/keyword/src/main.cpp
@@ -26,6 +26,7 @@
 #include "parser/parser.hpp"
 #include "parser/states/keywords/deps.hpp"
 #include "parser/states/keywords/files.hpp"
+#include "parser/states/keywords/inc.hpp"
 #include "parser/states/keywords/let.hpp"
 #include "parser/states/keywords/pre.hpp"
 #include "parser/states/keywords/project.hpp"
@@ -179,4 +180,20 @@ TEST_F(KeywordTest, TestProcessLetKeyword)
 
 	EXPECT_NO_THROW(instance_.Process(lexer));
 	EXPECT_TRUE(dynamic_cast<parser::states::keywords::Let*>(instance_.mediator_.GetState().get()));
+}
+
+/**
+ * @brief Check if the Process() method correctly handles the "!inc" keyword
+ * 
+ */
+TEST_F(KeywordTest, TestProcessIncKeyword)
+{
+	std::vector<std::unique_ptr<Token>> tokens{};
+	tokens.emplace_back(std::make_unique<Word>("inc"));
+
+	auto handler = std::make_unique<handlers::DummyHandler>(std::move(tokens));
+	fakes::lexer::Lexer lexer{kFilePath, std::move(handler)};
+
+	EXPECT_NO_THROW(instance_.Process(lexer));
+	EXPECT_TRUE(dynamic_cast<parser::states::keywords::Inc*>(instance_.mediator_.GetState().get()));
 }

--- a/tests/parser/states/keywords/CMakeLists.txt
+++ b/tests/parser/states/keywords/CMakeLists.txt
@@ -20,6 +20,7 @@
 add_subdirectory(cflags)
 add_subdirectory(deps)
 add_subdirectory(files)
+add_subdirectory(inc)
 add_subdirectory(let)
 add_subdirectory(post)
 add_subdirectory(pre)

--- a/tests/parser/states/keywords/inc/CMakeLists.txt
+++ b/tests/parser/states/keywords/inc/CMakeLists.txt
@@ -17,38 +17,25 @@
 # under the License.
 #
 
-project("keyword")
+project("inc")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/parser/states/keyword.cpp
+    ${CMAKE_SOURCE_DIR}/src/parser/states/keywords/inc.cpp
 )
 
 set(STUBS
     ${STUBS_FOLDER}/lexer/handlers/handler.cpp
+    ${STUBS_FOLDER}/lexer/lexer.cpp
     ${STUBS_FOLDER}/lexer/scanner.cpp
-    ${STUBS_FOLDER}/parser/exceptions/unexpectedendoffileexception.cpp
-    ${STUBS_FOLDER}/parser/exceptions/unexpectedkeywordexception.cpp
     ${STUBS_FOLDER}/parser/exceptions/unexpectedtokenexception.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/cflags.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/deps.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/files.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/inc.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/let.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/pre.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/post.cpp
-    ${STUBS_FOLDER}/parser/states/keywords/project.cpp
     ${STUBS_FOLDER}/parser/states/types/array.cpp
     ${STUBS_FOLDER}/parser/states/types/string.cpp
+    ${STUBS_FOLDER}/parser/states/state.cpp
     ${STUBS_FOLDER}/parser/states/statement.cpp
     ${STUBS_FOLDER}/parser/tokens/punctuator.cpp
-    ${STUBS_FOLDER}/parser/tokens/separator.cpp
+    ${STUBS_FOLDER}/parser/mediator.cpp
+    ${STUBS_FOLDER}/parser/parser.cpp
     ${STUBS_FOLDER}/scheduler/pipeline/job.cpp
-    
-    src/stubs/lexer/lexer.cpp
-    src/stubs/parser/states/state.cpp
-    src/stubs/parser/tokens/word.cpp
-    src/stubs/parser/mediator.cpp
-    src/stubs/parser/parser.cpp
 )
 
 add_executable(${PROJECT_NAME} 
@@ -56,10 +43,6 @@ add_executable(${PROJECT_NAME}
     ${STUBS}
 
     src/main.cpp
-)
-
-target_include_directories(${PROJECT_NAME} PUBLIC
-    include
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/parser/states/keywords/inc/src/main.cpp
+++ b/tests/parser/states/keywords/inc/src/main.cpp
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "lexer/lexer.hpp"
+#include "parser/states/keywords/inc.hpp"
+
+namespace fs = std::filesystem;
+
+/**
+ * @brief A text fixture to test parser::states::keywords::Inc component
+ * 
+ */
+class IncTest : public ::testing::Test
+{
+protected:
+	/**
+	 * @brief The default file path, used by the test suite
+	 * 
+	 */
+	static const fs::path kFilePath;
+
+	/**
+	 * @brief A mediator instance
+	 * 
+	 */
+	parser::Mediator mediator_;
+
+	/**
+	 * @brief The instance to test
+	 * 
+	 */
+	parser::states::keywords::Inc instance_{mediator_};
+};
+
+const fs::path IncTest::kFilePath{""};
+
+/**
+ * @brief Check if the Process() method correctly handles abscence of the leading bracket
+ * 
+ */
+TEST_F(IncTest, TestProcess)
+{
+	lexer::Lexer lexer{kFilePath};
+	EXPECT_NO_THROW(instance_.Process(lexer));
+}

--- a/tests/scheduler/exceptions/CMakeLists.txt
+++ b/tests/scheduler/exceptions/CMakeLists.txt
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-add_subdirectory(compilationerrorexception)
 add_subdirectory(linkerrorexception)
 add_subdirectory(nofilesspecifiedexception)
 add_subdirectory(postcompilationcommandexception)

--- a/tests/scheduler/pipeline/job/src/main.cpp
+++ b/tests/scheduler/pipeline/job/src/main.cpp
@@ -121,3 +121,15 @@ TEST_F(JobTest, TestSetPostCompilationCommands)
 
 	EXPECT_EQ(instance_.GetPostCompilationCommands(), commands);
 }
+
+/**
+ * @brief Check if the GetIncludeDirectories() method returns a reference to the correctly filled vector
+ * 
+ */
+TEST_F(JobTest, TestAddIncludeDirectory)
+{
+	const std::filesystem::path path{"some_path"};
+	instance_.AddIncludeDirectory(path);
+
+	EXPECT_EQ(instance_.GetIncludeDirectories().at(0), path);
+}

--- a/tests/scheduler/pipeline/pipeline/CMakeLists.txt
+++ b/tests/scheduler/pipeline/pipeline/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
 )
 
 set(STUBS
+    ${STUBS_FOLDER}/exceptions/filenotfoundexception.cpp
     ${STUBS_FOLDER}/scheduler/exceptions/compilationerrorexception.cpp
     ${STUBS_FOLDER}/scheduler/exceptions/linkerrorexception.cpp
     ${STUBS_FOLDER}/scheduler/exceptions/nofilesspecifiedexception.cpp

--- a/tests/scheduler/pipeline/pipeline/src/main.cpp
+++ b/tests/scheduler/pipeline/pipeline/src/main.cpp
@@ -23,7 +23,6 @@
 #include <stack>
 
 #include "exceptions/filenotfoundexception.hpp"
-#include "scheduler/exceptions/compilationerrorexception.hpp"
 #include "scheduler/exceptions/linkerrorexception.hpp"
 #include "scheduler/exceptions/nofilesspecifiedexception.hpp"
 #include "scheduler/pipeline/job.hpp"
@@ -52,27 +51,6 @@ TEST(PipelineTest, TestRun)
 }
 
 /**
- * @brief Check if the Run() method throws an exception when the compilation fails
- * 
- */
-TEST(PipelineTest, TestCompileFail)
-{
-	const std::filesystem::path file{"main.cpp"};
-	std::ofstream file_handle{file};
-	file_handle.close();
-
-	scheduler::pipeline::Job job{"test"};
-	job.SetProjectPath(std::filesystem::path{"test"});
-	job.AddFile(std::filesystem::path{"main.cpp"});
-
-	result.push(false);
-	scheduler::pipeline::Pipeline pipeline{std::move(job)};
-	EXPECT_THROW(pipeline.Run(), scheduler::exceptions::CompilationErrorException);
-
-	std::filesystem::remove(file);
-}
-
-/**
  * @brief Check if the Run() method throws an exception when the linking fails
  * 
  */
@@ -81,10 +59,7 @@ TEST(PipelineTest, TestLinkFail)
 	const std::filesystem::path file{"main.cpp"};
 	std::ofstream file_handle{file};
 	file_handle.close();
-
-	// Make the compilation "succeed"
 	result.push(false);
-	result.push(true);
 
 	scheduler::pipeline::Job job{"test"};
 	job.SetProjectPath(std::filesystem::path{"test"});

--- a/tests/scheduler/pipeline/pipeline/src/stubs/scheduler/pipeline/job.cpp
+++ b/tests/scheduler/pipeline/pipeline/src/stubs/scheduler/pipeline/job.cpp
@@ -91,4 +91,14 @@ const std::vector<std::string>& Job::GetPostCompilationCommands() const
 {
 	return post_commands_;
 }
+
+void Job::AddIncludeDirectory(std::filesystem::path value)
+{
+	include_directories_.push_back(std::move(value));
+}
+
+const std::vector<std::filesystem::path>& Job::GetIncludeDirectories() const
+{
+	return include_directories_;
+}
 } // namespace scheduler::pipeline

--- a/tests/scheduler/pipeline/pipeline/src/stubs/sys/nix/command.cpp
+++ b/tests/scheduler/pipeline/pipeline/src/stubs/sys/nix/command.cpp
@@ -46,4 +46,9 @@ bool Command::Execute()
 	result.pop();
 	return data;
 }
+
+std::string Command::GetOutput() const
+{
+	return {};
+}
 } // namespace sys::nix

--- a/tests/scheduler/pipeline/pipeline/src/stubs/sys/tools/compilerfactory.cpp
+++ b/tests/scheduler/pipeline/pipeline/src/stubs/sys/tools/compilerfactory.cpp
@@ -24,8 +24,12 @@
 
 namespace sys::tools
 {
-std::unique_ptr<Compiler> CompilerFactory::Create(const std::string& value, std::string flags)
+std::unique_ptr<Compiler>
+CompilerFactory::Create(const std::string& value,
+						std::string flags,
+						std::vector<std::filesystem::path> include_directories)
 {
-	return std::unique_ptr<Compiler>{new compilers::GNUPlusPlus(std::move(flags))};
+	return std::unique_ptr<Compiler>{
+		new compilers::GNUPlusPlus(std::move(flags), std::move(include_directories))};
 }
 } // namespace sys::tools

--- a/tests/scheduler/pipeline/pipeline/src/stubs/sys/tools/compilerfactory.cpp
+++ b/tests/scheduler/pipeline/pipeline/src/stubs/sys/tools/compilerfactory.cpp
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ * 
  *  http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -17,13 +17,15 @@
  * under the License.
  */
 
-#include "scheduler/exceptions/compilationerrorexception.hpp"
+#include "sys/tools/compilerfactory.hpp"
 
-namespace scheduler::exceptions
+#include "sys/exceptions/unsupportedcompilerexception.hpp"
+#include "sys/tools/compilers/gnuplusplus.hpp"
+
+namespace sys::tools
 {
-const std::string CompilationErrorException::kMessage{"Compilation failed for the file: "};
-
-CompilationErrorException::CompilationErrorException(const std::filesystem::path& file)
-	: std::runtime_error(kMessage + file.string())
-{}
-} // namespace scheduler::exceptions
+std::unique_ptr<Compiler> CompilerFactory::Create(const std::string& value, std::string flags)
+{
+	return std::unique_ptr<Compiler>{new compilers::GNUPlusPlus(std::move(flags))};
+}
+} // namespace sys::tools

--- a/tests/stubs/exceptions/filenotfoundexception.cpp
+++ b/tests/stubs/exceptions/filenotfoundexception.cpp
@@ -17,13 +17,13 @@
  * under the License.
  */
 
-#include "lexer/exceptions/filenotfoundexception.hpp"
+#include "exceptions/filenotfoundexception.hpp"
 
-namespace lexer::exceptions
+namespace exceptions
 {
 const std::string FileNotFoundException::kMessage{};
 
 FileNotFoundException::FileNotFoundException(const std::filesystem::path& path)
 	: std::runtime_error("")
 {}
-} // namespace lexer::exceptions
+} // namespace exceptions

--- a/tests/stubs/parser/states/keywords/inc.cpp
+++ b/tests/stubs/parser/states/keywords/inc.cpp
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "parser/states/keywords/inc.hpp"
+
+#include "parser/states/statement.hpp"
+
+namespace parser::states::keywords
+{
+Inc::Inc(Mediator& mediator)
+	: Array{mediator}
+{}
+
+void Inc::Process(lexer::Lexer& lexer)
+{
+	// noop
+}
+} // namespace parser::states::keywords

--- a/tests/stubs/scheduler/pipeline/job.cpp
+++ b/tests/stubs/scheduler/pipeline/job.cpp
@@ -90,4 +90,14 @@ const std::vector<std::string>& Job::GetPostCompilationCommands() const
 {
 	return post_commands_;
 }
+
+void Job::AddIncludeDirectory(std::filesystem::path value)
+{
+	// noop
+}
+
+const std::vector<std::filesystem::path>& Job::GetIncludeDirectories() const
+{
+	return include_directories_;
+}
 } // namespace scheduler::pipeline

--- a/tests/stubs/scheduler/pipeline/pipeline.cpp
+++ b/tests/stubs/scheduler/pipeline/pipeline.cpp
@@ -31,9 +31,4 @@ void Pipeline::Run() const
 {
 	// noop
 }
-
-void Pipeline::Compile(const std::filesystem::path& file, const std::filesystem::path& out) const
-{
-	// noop
-}
 } // namespace scheduler::pipeline

--- a/tests/stubs/sys/exceptions/compilationerrorexception.cpp
+++ b/tests/stubs/sys/exceptions/compilationerrorexception.cpp
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/exceptions/compilationerrorexception.hpp"
+
+namespace sys::exceptions
+{
+const std::string CompilationErrorException::kMessage{};
+
+CompilationErrorException::CompilationErrorException(const std::filesystem::path& file)
+	: std::runtime_error("")
+{}
+} // namespace sys::exceptions

--- a/tests/stubs/sys/exceptions/unsupportedcompilerexception.cpp
+++ b/tests/stubs/sys/exceptions/unsupportedcompilerexception.cpp
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/exceptions/unsupportedcompilerexception.hpp"
+
+namespace sys::exceptions
+{
+const std::string UnsupportedCompilerException::kMessage{};
+
+UnsupportedCompilerException::UnsupportedCompilerException(std::string project)
+	: std::runtime_error("")
+{}
+} // namespace sys::exceptions

--- a/tests/stubs/sys/tools/compilerfactory.cpp
+++ b/tests/stubs/sys/tools/compilerfactory.cpp
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/tools/compilerfactory.hpp"
+
+namespace sys::tools
+{
+std::unique_ptr<Compiler> CompilerFactory::Create(const std::string& value, std::string flags)
+{
+	return {};
+}
+} // namespace sys::tools

--- a/tests/stubs/sys/tools/compilerfactory.cpp
+++ b/tests/stubs/sys/tools/compilerfactory.cpp
@@ -21,7 +21,10 @@
 
 namespace sys::tools
 {
-std::unique_ptr<Compiler> CompilerFactory::Create(const std::string& value, std::string flags)
+std::unique_ptr<Compiler>
+CompilerFactory::Create(const std::string& value,
+						std::string flags,
+						std::vector<std::filesystem::path> include_directories)
 {
 	return {};
 }

--- a/tests/stubs/sys/tools/compilers/gnuplusplus.cpp
+++ b/tests/stubs/sys/tools/compilers/gnuplusplus.cpp
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/tools/compilers/gnuplusplus.hpp"
+
+namespace sys::tools::compilers
+{
+const std::string GNUPlusPlus::kCompiler{"g++"};
+
+GNUPlusPlus::GNUPlusPlus(std::string&& flags)
+	: kFlags{std::move(flags)}
+{}
+
+void GNUPlusPlus::Compile(const std::filesystem::path& file, const std::filesystem::path& out)
+{
+	// noop
+}
+} // namespace sys::tools::compilers

--- a/tests/stubs/sys/tools/compilers/gnuplusplus.cpp
+++ b/tests/stubs/sys/tools/compilers/gnuplusplus.cpp
@@ -23,8 +23,10 @@ namespace sys::tools::compilers
 {
 const std::string GNUPlusPlus::kCompiler{"g++"};
 
-GNUPlusPlus::GNUPlusPlus(std::string&& flags)
+GNUPlusPlus::GNUPlusPlus(std::string&& flags,
+						 std::vector<std::filesystem::path>&& include_directories)
 	: kFlags{std::move(flags)}
+	, kDirectories{std::move(include_directories)}
 {}
 
 void GNUPlusPlus::Compile(const std::filesystem::path& file, const std::filesystem::path& out)

--- a/tests/stubs/sys/tools/compilers/gnuplusplus.cpp
+++ b/tests/stubs/sys/tools/compilers/gnuplusplus.cpp
@@ -33,4 +33,11 @@ void GNUPlusPlus::Compile(const std::filesystem::path& file, const std::filesyst
 {
 	// noop
 }
+
+std::vector<std::filesystem::path>
+GNUPlusPlus::GetDependencies(const std::filesystem::path& file) const
+{
+	return {};
+}
+
 } // namespace sys::tools::compilers

--- a/tests/sys/CMakeLists.txt
+++ b/tests/sys/CMakeLists.txt
@@ -19,3 +19,4 @@
 
 add_subdirectory(exceptions)
 add_subdirectory(nix)
+add_subdirectory(tools)

--- a/tests/sys/exceptions/CMakeLists.txt
+++ b/tests/sys/exceptions/CMakeLists.txt
@@ -17,5 +17,4 @@
 # under the License.
 #
 
-add_subdirectory(exceptions)
-add_subdirectory(nix)
+add_subdirectory(unsupportedcompilerexception)

--- a/tests/sys/exceptions/compilationerrorexception/CMakeLists.txt
+++ b/tests/sys/exceptions/compilationerrorexception/CMakeLists.txt
@@ -17,31 +17,20 @@
 # under the License.
 #
 
-project("pipeline")
+project("compilationerrorexception")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/scheduler/pipeline/pipeline.cpp
-)
-
-set(STUBS
-    ${STUBS_FOLDER}/exceptions/filenotfoundexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/linkerrorexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/nofilesspecifiedexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/postcompilationcommandexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/precompilationcommandexception.cpp
-    ${STUBS_FOLDER}/sys/exceptions/compilationerrorexception.cpp
-    ${STUBS_FOLDER}/sys/tools/compilers/gnuplusplus.cpp
-    
-    src/stubs/scheduler/pipeline/job.cpp
-    src/stubs/sys/nix/command.cpp
-    src/stubs/sys/tools/compilerfactory.cpp
+    ${CMAKE_SOURCE_DIR}/src/sys/exceptions/compilationerrorexception.cpp
 )
 
 add_executable(${PROJECT_NAME} 
     ${SOURCES}
-    ${STUBS}
 
     src/main.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    include
 )
 
 add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/sys/exceptions/compilationerrorexception/include/fakes/sys/exceptions/compilationerrorexception.hpp
+++ b/tests/sys/exceptions/compilationerrorexception/include/fakes/sys/exceptions/compilationerrorexception.hpp
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "sys/exceptions/compilationerrorexception.hpp"
+
+namespace fakes::sys::exceptions
+{
+namespace exc = ::sys::exceptions;
+
+/**
+ * @brief An fake for the exception, used to notify that the compilation proces for the given file has failed
+ * 
+ */
+class CompilationErrorException : public exc::CompilationErrorException
+{
+public:
+	/**
+	 * @brief Construct a new CompilationErrorException object
+	 * 
+	 * @param file - the file that caused the error
+	 */
+	explicit CompilationErrorException(const std::filesystem::path& file)
+		: exc::CompilationErrorException{file}
+	{}
+
+public:
+	using exc::CompilationErrorException::kMessage;
+};
+} // namespace fakes::sys::exceptions

--- a/tests/sys/exceptions/compilationerrorexception/src/main.cpp
+++ b/tests/sys/exceptions/compilationerrorexception/src/main.cpp
@@ -17,33 +17,21 @@
  * under the License.
  */
 
-#pragma once
+#include <gtest/gtest.h>
 
-#include <filesystem>
-#include <stdexcept>
-#include <string>
+#include "fakes/sys/exceptions/compilationerrorexception.hpp"
 
-namespace scheduler::exceptions
-{
 /**
- * @brief An exception, used to notify that the compilation proces for the given file has failed
+ * @brief Check if the exception is constructed with the correct message
  * 
  */
-class CompilationErrorException : public std::runtime_error
+TEST(CompilationErrorExceptionTest, TestConstructor)
 {
-public:
-	/**
-	 * @brief Construct a new CompilationErrorException object
-	 * 
-	 * @param file - the file that caused the error
-	 */
-	explicit CompilationErrorException(const std::filesystem::path& file);
+	namespace exc = fakes::sys::exceptions;
+	namespace fs = std::filesystem;
 
-protected:
-	/**
-	 * @brief The message, seeing on the exception occurence
-	 * 
-	 */
-	static const std::string kMessage;
-};
-} // namespace scheduler::exceptions
+	const fs::path path{"path"};
+	const exc::CompilationErrorException exception{path};
+	const auto data = exc::CompilationErrorException::kMessage + path.string();
+	EXPECT_STREQ(exception.what(), data.c_str());
+}

--- a/tests/sys/exceptions/unsupportedcompilerexception/CMakeLists.txt
+++ b/tests/sys/exceptions/unsupportedcompilerexception/CMakeLists.txt
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+project("unsupportedcompilerexception")
+
+set(SOURCES 
+    ${CMAKE_SOURCE_DIR}/src/sys/exceptions/unsupportedcompilerexception.cpp
+)
+
+add_executable(${PROJECT_NAME} 
+    ${SOURCES}
+
+    src/main.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    include
+)
+
+add_test(NAME ${PROJECT_NAME} COMMAND ${PROJECT_NAME})

--- a/tests/sys/exceptions/unsupportedcompilerexception/include/fakes/sys/exceptions/unsupportedcompilerexception.hpp
+++ b/tests/sys/exceptions/unsupportedcompilerexception/include/fakes/sys/exceptions/unsupportedcompilerexception.hpp
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include "sys/exceptions/unsupportedcompilerexception.hpp"
+
+namespace fakes::sys::exceptions
+{
+/**
+ * @brief A fake for the exception, used to notify that the specified compiler is not supported
+ * 
+ */
+class UnsupportedCompilerException : public ::sys::exceptions::UnsupportedCompilerException
+{
+public:
+	/**
+	 * @brief Construct a new UnsupportedCompilerException object
+	 * 
+	 * @param project - the project that caused the error
+	 */
+	explicit UnsupportedCompilerException(std::string project)
+		: ::sys::exceptions::UnsupportedCompilerException{project}
+	{}
+
+public:
+	using ::sys::exceptions::UnsupportedCompilerException::kMessage;
+};
+} // namespace fakes::sys::exceptions

--- a/tests/sys/exceptions/unsupportedcompilerexception/src/main.cpp
+++ b/tests/sys/exceptions/unsupportedcompilerexception/src/main.cpp
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "fakes/sys/exceptions/unsupportedcompilerexception.hpp"
+
+/**
+ * @brief Check if the exception is constructed with the correct message
+ * 
+ */
+TEST(UnsupportedCompilerExceptionTest, TestConstructor)
+{
+	namespace exc = fakes::sys::exceptions;
+
+	const std::string compiler{"compiler"};
+	const exc::UnsupportedCompilerException exception{compiler};
+	const auto data = exc::UnsupportedCompilerException::kMessage + compiler;
+	EXPECT_STREQ(exception.what(), data.c_str());
+}

--- a/tests/sys/tools/CMakeLists.txt
+++ b/tests/sys/tools/CMakeLists.txt
@@ -17,5 +17,5 @@
 # under the License.
 #
 
-add_subdirectory(compilationerrorexception)
-add_subdirectory(unsupportedcompilerexception)
+add_subdirectory(compilerfactory)
+add_subdirectory(compilers)

--- a/tests/sys/tools/compilerfactory/CMakeLists.txt
+++ b/tests/sys/tools/compilerfactory/CMakeLists.txt
@@ -17,14 +17,20 @@
 # under the License.
 #
 
-project("compilationerrorexception")
+project("compilerfactory")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/scheduler/exceptions/compilationerrorexception.cpp
+    ${CMAKE_SOURCE_DIR}/src/sys/tools/compilerfactory.cpp
+)
+
+set(STUBS
+    ${STUBS_FOLDER}/sys/exceptions/unsupportedcompilerexception.cpp
+    ${STUBS_FOLDER}/sys/tools/compilers/gnuplusplus.cpp
 )
 
 add_executable(${PROJECT_NAME} 
     ${SOURCES}
+    ${STUBS}
 
     src/main.cpp
 )

--- a/tests/sys/tools/compilerfactory/src/main.cpp
+++ b/tests/sys/tools/compilerfactory/src/main.cpp
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "sys/exceptions/unsupportedcompilerexception.hpp"
+#include "sys/tools/compilerfactory.hpp"
+#include "sys/tools/compilers/gnuplusplus.hpp"
+
+/**
+ * @brief Check if the GNU Compiler for C++ is recognized as a possible compiler to use
+ * 
+ */
+TEST(CompilerFactoryTest, TestCreateGnuCompiler)
+{
+	const auto compiler = "g++";
+	const auto instance = sys::tools::CompilerFactory::Create(compiler, "");
+	EXPECT_TRUE(dynamic_cast<sys::tools::compilers::GNUPlusPlus*>(instance.get()));
+}
+
+/**
+ * @brief Check if the factory correctly throws an exception if the compiler was not recognized
+ * 
+ */
+TEST(CompilerFactoryTest, TestCreateUnsupportedCompiler)
+{
+	const auto compiler = "some_unknown_compiler";
+	EXPECT_THROW(sys::tools::CompilerFactory::Create(compiler, ""),
+				 sys::exceptions::UnsupportedCompilerException);
+}

--- a/tests/sys/tools/compilerfactory/src/main.cpp
+++ b/tests/sys/tools/compilerfactory/src/main.cpp
@@ -30,7 +30,9 @@
 TEST(CompilerFactoryTest, TestCreateGnuCompiler)
 {
 	const auto compiler = "g++";
-	const auto instance = sys::tools::CompilerFactory::Create(compiler, "");
+	const std::vector<std::filesystem::path> include_directories{};
+	const auto instance =
+		sys::tools::CompilerFactory::Create(compiler, "", std::vector<std::filesystem::path>{});
 	EXPECT_TRUE(dynamic_cast<sys::tools::compilers::GNUPlusPlus*>(instance.get()));
 }
 
@@ -41,6 +43,7 @@ TEST(CompilerFactoryTest, TestCreateGnuCompiler)
 TEST(CompilerFactoryTest, TestCreateUnsupportedCompiler)
 {
 	const auto compiler = "some_unknown_compiler";
-	EXPECT_THROW(sys::tools::CompilerFactory::Create(compiler, ""),
-				 sys::exceptions::UnsupportedCompilerException);
+	EXPECT_THROW(
+		sys::tools::CompilerFactory::Create(compiler, "", std::vector<std::filesystem::path>{}),
+		sys::exceptions::UnsupportedCompilerException);
 }

--- a/tests/sys/tools/compilers/CMakeLists.txt
+++ b/tests/sys/tools/compilers/CMakeLists.txt
@@ -17,5 +17,4 @@
 # under the License.
 #
 
-add_subdirectory(compilationerrorexception)
-add_subdirectory(unsupportedcompilerexception)
+add_subdirectory(gnuplusplus)

--- a/tests/sys/tools/compilers/gnuplusplus/CMakeLists.txt
+++ b/tests/sys/tools/compilers/gnuplusplus/CMakeLists.txt
@@ -17,24 +17,16 @@
 # under the License.
 #
 
-project("pipeline")
+project("gnuplusplus")
 
 set(SOURCES 
-    ${CMAKE_SOURCE_DIR}/src/scheduler/pipeline/pipeline.cpp
+    ${CMAKE_SOURCE_DIR}/src/sys/tools/compilers/gnuplusplus.cpp
 )
 
 set(STUBS
-    ${STUBS_FOLDER}/exceptions/filenotfoundexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/linkerrorexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/nofilesspecifiedexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/postcompilationcommandexception.cpp
-    ${STUBS_FOLDER}/scheduler/exceptions/precompilationcommandexception.cpp
     ${STUBS_FOLDER}/sys/exceptions/compilationerrorexception.cpp
-    ${STUBS_FOLDER}/sys/tools/compilers/gnuplusplus.cpp
     
-    src/stubs/scheduler/pipeline/job.cpp
     src/stubs/sys/nix/command.cpp
-    src/stubs/sys/tools/compilerfactory.cpp
 )
 
 add_executable(${PROJECT_NAME} 

--- a/tests/sys/tools/compilers/gnuplusplus/src/main.cpp
+++ b/tests/sys/tools/compilers/gnuplusplus/src/main.cpp
@@ -23,6 +23,7 @@
 #include "sys/tools/compilers/gnuplusplus.hpp"
 
 extern bool result;
+extern std::string output;
 
 /**
  * @brief Check if the compilation fails and throws an exception, if the system command returns false
@@ -45,8 +46,27 @@ TEST(GNUPlusPlusTest, TestCompileFail)
  */
 TEST(GNUPlusPlusTest, TestCompileSuccess)
 {
+	const std::string dependency = "c.cpp";
+	output = "main.o: main.cpp " + dependency;
+
 	sys::tools::compilers::GNUPlusPlus compiler{"", std::vector<std::filesystem::path>{}};
 
 	const std::filesystem::path file{"main.cpp"};
 	EXPECT_NO_THROW(compiler.Compile(file, file));
+}
+
+/**
+ * @brief Check if the GetDependencies() method return the expected dependencies
+ * 
+ */
+TEST(GNUPlusPlusTest, TestGetDependencies)
+{
+	const std::string dependency = "c.cpp";
+	output = "main.o: main.cpp " + dependency;
+
+	sys::tools::compilers::GNUPlusPlus compiler{"", std::vector<std::filesystem::path>{}};
+
+	const std::filesystem::path file{"main.cpp"};
+	const auto dependencies = compiler.GetDependencies(file);
+	EXPECT_EQ(dependencies.at(0), std::filesystem::path{"c.cpp"});
 }

--- a/tests/sys/tools/compilers/gnuplusplus/src/main.cpp
+++ b/tests/sys/tools/compilers/gnuplusplus/src/main.cpp
@@ -30,7 +30,7 @@ extern bool result;
  */
 TEST(GNUPlusPlusTest, TestCompileFail)
 {
-	sys::tools::compilers::GNUPlusPlus compiler{""};
+	sys::tools::compilers::GNUPlusPlus compiler{"", std::vector<std::filesystem::path>{}};
 
 	result = false;
 	const std::filesystem::path file{"main.cpp"};
@@ -45,7 +45,7 @@ TEST(GNUPlusPlusTest, TestCompileFail)
  */
 TEST(GNUPlusPlusTest, TestCompileSuccess)
 {
-	sys::tools::compilers::GNUPlusPlus compiler{""};
+	sys::tools::compilers::GNUPlusPlus compiler{"", std::vector<std::filesystem::path>{}};
 
 	const std::filesystem::path file{"main.cpp"};
 	EXPECT_NO_THROW(compiler.Compile(file, file));

--- a/tests/sys/tools/compilers/gnuplusplus/src/main.cpp
+++ b/tests/sys/tools/compilers/gnuplusplus/src/main.cpp
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "sys/exceptions/compilationerrorexception.hpp"
+#include "sys/tools/compilers/gnuplusplus.hpp"
+
+extern bool result;
+
+/**
+ * @brief Check if the compilation fails and throws an exception, if the system command returns false
+ * 
+ */
+TEST(GNUPlusPlusTest, TestCompileFail)
+{
+	sys::tools::compilers::GNUPlusPlus compiler{""};
+
+	result = false;
+	const std::filesystem::path file{"main.cpp"};
+	EXPECT_THROW(compiler.Compile(file, file), sys::exceptions::CompilationErrorException);
+
+	result = true;
+}
+
+/**
+ * @brief Check if the Compile() method doesn't throw any exception if the system command is run successfully
+ * 
+ */
+TEST(GNUPlusPlusTest, TestCompileSuccess)
+{
+	sys::tools::compilers::GNUPlusPlus compiler{""};
+
+	const std::filesystem::path file{"main.cpp"};
+	EXPECT_NO_THROW(compiler.Compile(file, file));
+}

--- a/tests/sys/tools/compilers/gnuplusplus/src/stubs/sys/nix/command.cpp
+++ b/tests/sys/tools/compilers/gnuplusplus/src/stubs/sys/nix/command.cpp
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "sys/nix/command.hpp"
+
+bool result{true};
+
+namespace sys::nix
+{
+Command::Command(std::string line)
+{
+	// noop
+}
+
+Command::Command(std::string program, std::string parameters)
+{
+	// noop
+}
+
+bool Command::Execute()
+{
+	return result;
+}
+} // namespace sys::nix

--- a/tests/sys/tools/compilers/gnuplusplus/src/stubs/sys/nix/command.cpp
+++ b/tests/sys/tools/compilers/gnuplusplus/src/stubs/sys/nix/command.cpp
@@ -37,4 +37,9 @@ bool Command::Execute()
 {
 	return result;
 }
+
+std::string Command::GetOutput() const
+{
+	return {};
+}
 } // namespace sys::nix

--- a/tests/sys/tools/compilers/gnuplusplus/src/stubs/sys/nix/command.cpp
+++ b/tests/sys/tools/compilers/gnuplusplus/src/stubs/sys/nix/command.cpp
@@ -20,6 +20,7 @@
 #include "sys/nix/command.hpp"
 
 bool result{true};
+std::string output{};
 
 namespace sys::nix
 {
@@ -40,6 +41,6 @@ bool Command::Execute()
 
 std::string Command::GetOutput() const
 {
-	return {};
+	return output;
 }
 } // namespace sys::nix


### PR DESCRIPTION
This commit adds a lot of new things, like a new !inc keyword, used for adding include folders to the project and skipping feature, which means if the object file is older than the original file and all it's dependencies, then the compilation process is skipped for the file.